### PR TITLE
make scripts in doc/utils work with python 2/3

### DIFF
--- a/docs/format/source/conf_get_pynwb.py
+++ b/docs/format/source/conf_get_pynwb.py
@@ -1,5 +1,5 @@
 try:  #Python 2
-    from urlib import urlretrieve
+    from urllib import urlretrieve
 except ImportError:   # Python 3
     from urllib.request import urlretrieve
 

--- a/docs/utils/generate_format_docs.py
+++ b/docs/utils/generate_format_docs.py
@@ -5,8 +5,9 @@ Generate figures and RST documents from the NWB YAML specification for the forma
 # TODO In the type hierarchy section add a section to order types by based on which YAML file they appear in
 # TODO In the sections describing the different types add the name of the source YAML file
 
+# Python 2/3 compatibility
+from __future__ import print_function
 
-#from pynwb.spec import SpecCatalog
 from form.spec.spec import GroupSpec, DatasetSpec, LinkSpec, AttributeSpec
 from pynwb.spec import NWBGroupSpec, NWBDatasetSpec, NWBNamespace
 from form.spec.namespace import NamespaceCatalog
@@ -47,7 +48,7 @@ try:
         spec_input_namespace_filename, \
         spec_input_default_namespace
 except ImportError:
-    print("Could not import SPHINX conf_doc_autogen.py file. Please add the PYTHONPATH to the source directory where the conf.py file is located")
+    print("Could not import SPHINX conf_doc_autogen.py file. Please add the PYTHONPATH to the source directory where the conf_doc_autogen.py file is located")
     exit(0)
 
 try:

--- a/docs/utils/init_sphinx_extension_doc.py
+++ b/docs/utils/init_sphinx_extension_doc.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
 from subprocess import check_call, CalledProcessError
 import argparse
 import os

--- a/docs/utils/render.py
+++ b/docs/utils/render.py
@@ -43,12 +43,16 @@ class SpecFormatter(object):
         :return: YAML string for the current specification
         """
         import json
+        import sys
         try:
             from ruamel import yaml
         except:
             import yaml
         clean_spec = json.loads(SpecFormatter.spec_to_json(spec, pretty=True))
-        return yaml.dump(clean_spec, default_flow_style=False)
+        if sys.version_info[0] == 3:
+            return yaml.dump(clean_spec, default_flow_style=False)
+        else:
+            return yaml.safe_dump(clean_spec, default_flow_style=False)
 
     @classmethod
     def spec_to_rst(cls, spec):


### PR DESCRIPTION
Various fixes to make the ``render.py``,  ``generate_format_docs.py`` and ``init_sphinx_extension_doc.py``scripts in ``docs/utils`` also work properly in Python 2. Fix #69