### PR TITLE
Fix download links on publication page 

### DIFF
--- a/docs/general/source/publications.rst
+++ b/docs/general/source/publications.rst
@@ -10,7 +10,7 @@ NWB:N Version 2
 
 .. figure:: pubs/ruebel_sfn_2017.*
    :scale: 100 %
-   :target: pubs/ruebel_sfn_2017.pdf
+   :target: https://github.com/NeurodataWithoutBorders/nwb-schema/raw/dev/docs/general/source/pubs/ruebel_sfn_2017.pdf
    :alt: Poster by Ruebel and Tritt et al. presented at SfN 2017
 
 
@@ -19,7 +19,7 @@ NWB:N Version 2
   without borders (NWB) to enable efficient management, use and sharing of neurophysiology data,"
   Neuroscience 2017, Society for Neuroscience, Nov. 11, 2017, Washington D.C.
   (Poster) `(online abstract) <http://www.abstractsonline.com/pp8/#!/4376/presentation/22013>`_
-  `(pdf) <doc/ruebel_sfn_2017.pdf>`_
+  `(pdf) <https://github.com/NeurodataWithoutBorders/nwb-schema/raw/dev/docs/general/source/pubs/ruebel_sfn_2017.pdf>`_
 
 
 ===============


### PR DESCRIPTION
Relative links on ReadTheDocs failed for download so pointing to GitHub instead. 