### PR TITLE
Catch up schema with changes for adding trial support. See https://gi…

### DIFF
--- a/core/nwb.base.yaml
+++ b/core/nwb.base.yaml
@@ -5,6 +5,17 @@ datasets:
     name: help
   doc: The attributes specified here are included in all interfaces.
   neurodata_type_def: NWBData
+- attributes:
+  - doc: Value is 'One of many columns that can be added to a DynamicTable'
+    dtype: text
+    value: One of many columns that can be added to a DynamicTable
+    name: help
+  - doc: A short description of what this column stores
+    dtype: text
+    name: description
+  doc: The attributes specified here are included in all interfaces.
+  neurodata_type_def: TableColumn
+  neurodata_type_inc: NWBData
 - default_name: vector_data
   attributes:
   - doc: a help string
@@ -201,4 +212,44 @@ groups:
   default_name: Images
   doc: A NWBDataInterface for storing images that have some relationship
   neurodata_type_def: Images
+  neurodata_type_inc: NWBDataInterface
+- attributes:
+  - doc: Value is 'A column-centric table'
+    dtype: text
+    name: help
+    value: A column-centric table
+  - doc: The names of the columns in this table. This should be used to specifying an order to the columns
+    dtype: text
+    name: colnames
+    shape:
+      - null
+  - doc: Description of what is in this dynamic table
+    dtype: text
+    name: description
+  datasets:
+    - name: id
+      neurodata_type_inc: ElementIdentifiers
+      doc: The unique identifier for the rows in this dynamic table
+      dtype: int
+      shape:
+        - null
+    - doc: The columns in this dynamic table
+      neurodata_type_inc: TableColumn
+      quantity: '*'
+  doc: A group containing multiple datasets that are aligned on the first dimension (Currently, this requirement
+    if left up to APIs to check and enforce). Apart from a column that contains unique identifiers for each row
+    there are no other required datasets. Users are free to add any number of TableColumn objects here. Table
+    functionality is already supported through compound types, which is analogous to storing an array-of-structs.
+    DynamicTable can be thought of as a struct-of-arrays. This provides an alternative structure to choose from
+    when optimizing storage for anticipated access patterns. Additionally, this type provides a way of creating a
+    table without having to define a compound type up front. Although this convenience may be attractive, users
+    should think carefully about how data will be accessed. DynamicTable is more appropriate for column-centric
+    access, whereas a dataset with a compound type would be more appropriate for row-centric access. Finally,
+    data size should also be taken into account. For small tables, performance loss may be an acceptable trade-off
+    for the flexibility of a DynamicTable. For example, DynamicTable was originally developed for storing trial
+    data and spike unit metadata. Both of these use cases are expected to produce relatively small tables, so
+    the spatial locality of multiple datasets present in a DynamicTable is not expected to have a significant performance
+    impact. Additionally, requirements of trial and unit metadata tables are sufficiently diverse that performance
+    implications can be overlooked in favor of usability.
+  neurodata_type_def: DynamicTable
   neurodata_type_inc: NWBDataInterface

--- a/core/nwb.behavior.yaml
+++ b/core/nwb.behavior.yaml
@@ -20,7 +20,7 @@ groups:
     - num_times
     - num_features
     doc: 2-D array storing position or direction relative to some reference frame.
-    dtype: number
+    dtype: float
     name: data
     shape:
     - null

--- a/core/nwb.ecephys.yaml
+++ b/core/nwb.ecephys.yaml
@@ -19,7 +19,7 @@ groups:
     - - num_times
       - num_channels
     doc: Recorded voltage data.
-    dtype: number
+    dtype: float
     name: data
     shape:
     - - null

--- a/core/nwb.epoch.yaml
+++ b/core/nwb.epoch.yaml
@@ -76,6 +76,10 @@ groups:
     dtype: text
     name: help
     value: A general epoch object
+  groups:
+    - name: metadata
+      doc: a DynamicTable for storing metadata about epochs
+      neurodata_type_inc: DynamicTable
   datasets:
     - name: epochs
       doc: the EpochTable holding information about each Epoch

--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -83,6 +83,7 @@ groups:
     \ different start/stop times."
     neurodata_type_inc: Epochs
     name: epochs
+    quantity: '?'
   - doc: "The home for processing Modules. These modules perform intermediate analysis\
       \ of data that is necessary to perform before scientific analysis. Examples\
       \ include spike clustering, extracting position from tracking data, stitching\
@@ -272,7 +273,7 @@ groups:
         dtype: text
         name: genotype
         quantity: '?'
-      - doc: Sex of subject
+      - doc: Gender of subject
         dtype: text
         name: sex
         quantity: '?'
@@ -320,9 +321,9 @@ groups:
         quantity: '*'
       name: intracellular_ephys
       quantity: '?'
-    - doc: Metadata describing optogenetic stimulation
+    - doc: Metadata describing optogenetic stimuluation
       groups:
-      - doc: 'One of possibly many groups describing an optogenetic stimulation site.
+      - doc: 'One of possibly many groups describing an optogenetic stimuluation site.
           COMMENT: Name is arbitrary but should be meaningful. Name is referenced
           by OptogeneticSeries'
         neurodata_type_inc: OptogeneticStimulusSite
@@ -339,6 +340,29 @@ groups:
       name: optophysiology
       quantity: '?'
     name: general
+  - doc: 'Data about experimental trials'
+    name: trials
+    neurodata_type_inc: DynamicTable
+    quantity: '?'
+    datasets:
+    - doc: The start time of each trial
+      attributes:
+        - name: description
+          value: the start time of each trial
+          dtype: text
+          doc: Value is 'the start time of each trial'
+      name: start
+      neurodata_type_inc: TableColumn
+      dtype: float
+    - doc: The end time of each trial
+      attributes:
+        - name: description
+          value: the end time of each trial
+          dtype: text
+          doc: Value is 'the end time of each trial'
+      name: end
+      neurodata_type_inc: TableColumn
+      dtype: float
   name: root
   neurodata_type_def: NWBFile
   neurodata_type_inc: NWBContainer

--- a/core/nwb.icephys.yaml
+++ b/core/nwb.icephys.yaml
@@ -8,7 +8,7 @@ groups:
   - dims:
     - num_times
     doc: Recorded voltage or current.
-    dtype: number
+    dtype: float
     name: data
     shape:
     - null
@@ -194,7 +194,6 @@ groups:
   - doc: Name(s) of devices in general/devices
     dtype: text
     name: device
-    quantity: '?'
   - doc: Electrode specific filtering.
     dtype: text
     name: filtering

--- a/core/nwb.image.yaml
+++ b/core/nwb.image.yaml
@@ -20,7 +20,7 @@ groups:
       - y
       - x
     doc: Either binary data containing image or empty.
-    dtype: number
+    dtype: int8
     name: data
     shape:
     - - null

--- a/core/nwb.misc.yaml
+++ b/core/nwb.misc.yaml
@@ -13,7 +13,7 @@ groups:
         \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
         \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
         \ below describes how to convert the data to the specified SI unit."
-      dtype: None
+      dtype: text
       name: unit
       required: false
     dims:
@@ -58,15 +58,15 @@ groups:
   datasets:
   - attributes:
     - doc: Value is 'float('NaN')'
-      dtype: None
+      dtype: float
       name: conversion
       value: NaN
     - doc: Value is 'float('NaN')'
-      dtype: None
+      dtype: float
       name: resolution
       value: NaN
     - doc: Value is 'n/a'
-      dtype: None
+      dtype: text
       name: unit
       value: n/a
     dims:
@@ -90,15 +90,15 @@ groups:
   datasets:
   - attributes:
     - doc: Value is 'float('NaN')'
-      dtype: None
+      dtype: float
       name: conversion
       value: NaN
     - doc: Value is 'float('NaN')'
-      dtype: None
+      dtype: float
       name: resolution
       value: NaN
     - doc: Value is 'n/a'
-      dtype: None
+      dtype: text
       name: unit
       value: n/a
     dims:

--- a/core/nwb.ogen.yaml
+++ b/core/nwb.ogen.yaml
@@ -47,7 +47,7 @@ groups:
   - doc: Location of stimulation site
     dtype: text
     name: location
-  doc: 'One of possibly many groups describing an optogenetic stimulation site. COMMENT:
+  doc: 'One of possibly many groups describing an optogenetic stimuluation site. COMMENT:
     Name is arbitrary but should be meaningful. Name is referenced by OptogeneticSeries'
   neurodata_type_def: OptogeneticStimulusSite
   neurodata_type_inc: NWBContainer


### PR DESCRIPTION
# Motivation

Catch schema up with changes for adding trial structure. See https://github.com/NeurodataWithoutBorders/pynwb/pull/536

# Major changes:
* Add ``DynamicTable`` neurodata_type for column-based data tables that can be more easily expanded (by adding colmns) without having to create custom extensions
* Add ``TableColmn`` neurodata_type to define the column of a ``DynamicTable`` data
* Change dtype from generic ``number`` to more specific type:
       * to ``float`` for``SpatialSeries.data``
       *  to ``int8`` for ``ImageSeries.data``
* Change dtype from unspecified ``None`` to more specific type:
      * ``float`` for ``AnnotationSeries.data.conversion``, ``AnnotationSeries.data.resolution``, ``IntervalSeries.data.conversion``, ``IntervalSeries.data.resolution`` attributes
      * ``test`` for ``AbstractFeatureSerie.data.unit``,``AnnotationSeries.data.unit``, ``IntervalSeries.data.unit`` attributes
* Add ``metadata`` group of type ``DynamicTable`` to ``Epochs`` type
* Change ``Sex`` to ``Gender`` in ``Subject`` metadata
* Add ``trials`` group for storing trial data

# Note

Credit for implementing these changes goes to @ajtritt . I'm just helping with catching up the schema repo. 