### PR TITLE
Deprecate manifold in favor of pixel_origin and pixel_deltas

### DIFF
--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -207,7 +207,7 @@ groups:
       - null
       - 3
     doc: "DEPRECATED Physical position of each pixel. 'xyz' represents the position\
-      \ of the pixel relative to the defined coordinate space. Deprecated in favor of pixel_origin and pixel_deltas."
+      \ of the pixel relative to the defined coordinate space. Deprecated in favor of origin_coords and grid_spacing."
     quantity: '?'
     attributes:
     - name: conversion

--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -234,7 +234,7 @@ groups:
     shape:
     - 2
     - 3
-    doc: Location of the origin in x, y or x, y, z, in meters
+    doc: Location of the origin in x, y or x, y, z, in the specified unit.
     required: false
     attributes:
     - name: unit
@@ -249,7 +249,8 @@ groups:
     shape:
     - 2
     - 3
-    doc: Space between pixels in x, y or x, y, z directions. Assumes imaging plane is a regular grid.
+    doc: Space between pixels in x, y or x, y, z directions, in the specified unit.
+      Assumes imaging plane is a regular grid.
     required: false
     attributes:
     - name: unit

--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -206,8 +206,8 @@ groups:
       - null
       - null
       - 3
-    doc: "Physical position of each pixel. 'xyz' represents the position\
-      \ of the pixel relative to the defined coordinate space."
+    doc: "DEPRECATED Physical position of each pixel. 'xyz' represents the position\
+      \ of the pixel relative to the defined coordinate space. Deprecated in favor of pixel_origin and pixel_deltas."
     quantity: '?'
     attributes:
     - name: conversion
@@ -224,9 +224,38 @@ groups:
     - name: unit
       dtype: text
       default_value: meters
-      doc: Base unit of measurement for working with the data. The default value
-        is 'meters'.
+      doc: Base unit of measurement for working with the data. The default value is 'meters'.
       required: false
+  - name: pixel_origin
+    dtype: float
+    dims:
+    - x, y
+    - x, y, z
+    shape:
+    - 2
+    - 3
+    doc: Location of the origin in x, y or x, y, z, in meters
+    required: false
+    attributes:
+    - name: unit
+      dtype: text
+      default_value: meters
+      doc: Measurement units for pixel_origin. The default value is 'meters'.
+  - name: pixel_deltas
+    dtype: float
+    dims:
+    - x, y
+    - x, y, z
+    shape:
+    - 2
+    - 3
+    doc: Space between pixels in x, y or x, y, z directions. Assumes imaging plane is a regular grid.
+    required: false
+    attributes:
+    - name: unit
+      dtype: text
+      default_value: meters
+      doc: Measurement units for pixel_deltas. The default value is 'meters'.
   - name: reference_frame
     dtype: text
     doc: Describes position and reference frame of manifold based on position of

--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -226,7 +226,7 @@ groups:
       default_value: meters
       doc: Base unit of measurement for working with the data. The default value is 'meters'.
       required: false
-  - name: pixel_origin
+  - name: origin_coords
     dtype: float
     dims:
     - x, y
@@ -234,14 +234,14 @@ groups:
     shape:
     - 2
     - 3
-    doc: Location of the origin in x, y or x, y, z, in the specified unit.
+    doc: Location of the origin in (x, y) or (x, y, z), in the specified unit.
     required: false
     attributes:
     - name: unit
       dtype: text
       default_value: meters
-      doc: Measurement units for pixel_origin. The default value is 'meters'.
-  - name: pixel_deltas
+      doc: Measurement units for origin_coords. The default value is 'meters'.
+  - name: grid_spacing
     dtype: float
     dims:
     - x, y
@@ -249,14 +249,14 @@ groups:
     shape:
     - 2
     - 3
-    doc: Space between pixels in x, y or x, y, z directions, in the specified unit.
+    doc: Space between pixels in (x, y) or voxels in (x, y, z) directions, in the specified unit.
       Assumes imaging plane is a regular grid.
     required: false
     attributes:
     - name: unit
       dtype: text
       default_value: meters
-      doc: Measurement units for pixel_deltas. The default value is 'meters'.
+      doc: Measurement units for grid_spacing. The default value is 'meters'.
   - name: reference_frame
     dtype: text
     doc: Describes position and reference frame of manifold based on position of


### PR DESCRIPTION
Implementing spec changes from https://github.com/NeurodataWithoutBorders/pynwb/pull/576