### PR TITLE
Update documentation for ImagingPlane.reference_frame

### DIFF
--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -246,7 +246,7 @@ groups:
     - 2
     - 3
     doc: Space between pixels in (x, y) or voxels in (x, y, z) directions, in the specified unit.
-      Assumes imaging plane is a regular grid.
+      Assumes imaging plane is a regular grid. See also reference_frame to interpret the grid.
     required: false
     attributes:
     - name: unit
@@ -260,6 +260,13 @@ groups:
       defined by origin_coords and grid_spacing or the vectors needed to transform or rotate the grid to
       a common anatomical axis (e.g., AP/DV/ML). This field is necessary to interpret origin_coords and grid_spacing.
       If origin_coords and grid_spacing are not present, then this field is not required.
+      For example, if the microscope takes 10 x 10 x 2 images, where the origin, here defined as bregma, is at pixel
+      (x=6, y=8, z=0) zero-indexed, the spacing between pixels is 0.2 mm in x and 0.2 mm in y and 0.5 mm in z, and
+      larger numbers in x means more anterior, larger numbers in y means more rightward, and larger numbers in z means
+      more ventral, then enter the following -- origin_coords = (6, 8, 0), grid_spacing = (0.2, 0.2, 0.5), and
+      reference_frame = "First dimension corresponds to anterior-posterior axis (larger index = more anterior). Second
+      dimension corresponds to medial-lateral axis (larger index = more rightward). Third dimension corresponds to
+      dorsal-ventral axis (larger index = more ventral). The origin is at bregma."
     quantity: '?'
   groups:
   - neurodata_type_def: OpticalChannel

--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -261,8 +261,8 @@ groups:
     dtype: text
     doc: Describes reference frame of origin_coords and grid_spacing.
       For example, this can be a text description of the anatomical location and orientation of the grid
-      defined by origin_coords and grid_spacing or the vectors needed to rotate to common anatomical axis
-      (e.g., AP/DV/ML). This field is necessary to interpret origin_coords and grid_spacing.
+      defined by origin_coords and grid_spacing or the vectors needed to transform or rotate the grid to
+      a common anatomical axis (e.g., AP/DV/ML). This field is necessary to interpret origin_coords and grid_spacing.
       If origin_coords and grid_spacing are not present, then this field is not required.
     quantity: '?'
   groups:

--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -234,9 +234,14 @@ groups:
     shape:
     - 2
     - 3
-    doc: Pixel location of the origin in (x, y) or (x, y, z), zero-indexed. See also reference_frame to interpret the
-      origin.
+    doc: Physical location of the first element of the imaging plane (0, 0) for 2-D data or (0, 0, 0) for 3-D data.
+      See also reference_frame for what the physical location is relative to (e.g., bregma).
     required: false
+    attributes:
+    - name: unit
+      dtype: text
+      default_value: meters
+      doc: Measurement units for origin_coords. The default value is 'meters'.
   - name: grid_spacing
     dtype: float
     dims:
@@ -260,13 +265,15 @@ groups:
       defined by origin_coords and grid_spacing or the vectors needed to transform or rotate the grid to
       a common anatomical axis (e.g., AP/DV/ML). This field is necessary to interpret origin_coords and grid_spacing.
       If origin_coords and grid_spacing are not present, then this field is not required.
-      For example, if the microscope takes 10 x 10 x 2 images, where the origin, here defined as bregma, is at pixel
-      (x=6, y=8, z=0) zero-indexed, the spacing between pixels is 0.2 mm in x and 0.2 mm in y and 0.5 mm in z, and
-      larger numbers in x means more anterior, larger numbers in y means more rightward, and larger numbers in z means
-      more ventral, then enter the following -- origin_coords = (6, 8, 0), grid_spacing = (0.2, 0.2, 0.5), and
-      reference_frame = "First dimension corresponds to anterior-posterior axis (larger index = more anterior). Second
-      dimension corresponds to medial-lateral axis (larger index = more rightward). Third dimension corresponds to
-      dorsal-ventral axis (larger index = more ventral). The origin is at bregma."
+      For example, if the microscope takes 10 x 10 x 2 images, where the first value of the data matrix
+      (index (0, 0, 0)) corresponds to (-1.2, -0.6, -2) mm relative to bregma, the spacing between pixels is 0.2 mm in
+      x, 0.2 mm in y and 0.5 mm in z, and larger numbers in x means more anterior, larger numbers in y means more
+      rightward, and larger numbers in z means more ventral, then enter the following --
+      origin_coords = (-1.2, -0.6, -2)
+      grid_spacing = (0.2, 0.2, 0.5)
+      reference_frame = "Origin coordinates are relative to bregma. First dimension corresponds to anterior-posterior
+      axis (larger index = more anterior). Second dimension corresponds to medial-lateral axis (larger index = more
+      rightward). Third dimension corresponds to dorsal-ventral axis (larger index = more ventral)."
     quantity: '?'
   groups:
   - neurodata_type_def: OpticalChannel

--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -234,13 +234,9 @@ groups:
     shape:
     - 2
     - 3
-    doc: Location of the origin in (x, y) or (x, y, z), in the specified unit.
+    doc: Pixel location of the origin in (x, y) or (x, y, z), zero-indexed. See also reference_frame to interpret the
+      origin.
     required: false
-    attributes:
-    - name: unit
-      dtype: text
-      default_value: meters
-      doc: Measurement units for origin_coords. The default value is 'meters'.
   - name: grid_spacing
     dtype: float
     dims:

--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -259,11 +259,11 @@ groups:
       doc: Measurement units for grid_spacing. The default value is 'meters'.
   - name: reference_frame
     dtype: text
-    doc: Describes position and reference frame of manifold based on position of
-      first element in manifold. For example, text description of anatomical location
-      or vectors needed to rotate to common anatomical axis (eg, AP/DV/ML). This
-      field is necessary to interpret manifold. If manifold is not present then
-      this field is not required.
+    doc: Describes reference frame of origin_coords and grid_spacing.
+      For example, this can be a text description of the anatomical location and orientation of the grid
+      defined by origin_coords and grid_spacing or the vectors needed to rotate to common anatomical axis
+      (e.g., AP/DV/ML). This field is necessary to interpret origin_coords and grid_spacing.
+      If origin_coords and grid_spacing are not present, then this field is not required.
     quantity: '?'
   groups:
   - neurodata_type_def: OpticalChannel


### PR DESCRIPTION
https://github.com/NeurodataWithoutBorders/nwb-schema/pull/305 deprecated `manifold` of `ImagingPlane` but the documentation for the `reference_frame` dataset still refers to `manifold`. This PR updates that documentation to refer to the new datasets instead of `manifold`.