### PR TITLE
Change electrode table columns to be text instead of ascii

### DIFF
--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -331,7 +331,7 @@ groups:
           doc: Impedance of the channel.
         - name: location
           neurodata_type_inc: VectorData
-          dtype: ascii
+          dtype: text
           doc: Location of the electrode (channel). Specify the area, layer, comments
             on estimation of area/layer, stereotaxic coordinates if in vivo, etc. Use
             standard atlas names for anatomical regions when possible.
@@ -347,7 +347,7 @@ groups:
           doc: Reference to the ElectrodeGroup this electrode is a part of.
         - name: group_name
           neurodata_type_inc: VectorData
-          dtype: ascii
+          dtype: text
           doc: Name of the ElectrodeGroup this electrode is a part of.
         - name: rel_x
           neurodata_type_inc: VectorData

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -15,6 +15,9 @@ Release Notes
 
 - Deprecated ImagingPlane "manifold" in favor of "origin_coords" and "grid_spacing"
 
+- Use "text" data type for DynamicTable column names and for electrode table columns "location" and "group_name". Previously, only ASCII was allowed.
+
+
 2.1.0 (September 2019)
 ----------------------
 

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -15,7 +15,9 @@ Release Notes
 
 - Deprecated ImagingPlane "manifold" in favor of "origin_coords" and "grid_spacing"
 
-- Use "text" data type for DynamicTable column names and for electrode table columns "location" and "group_name". Previously, only ASCII was allowed.
+- Use "text" data type for all DynamicTable "colnames". Previously, only ASCII was allowed.
+
+- Use "text" data type for electrode table columns "location" and "group_name". Previously, only ASCII was allowed.
 
 
 2.1.0 (September 2019)


### PR DESCRIPTION
In the spirit of removing ASCII from the hdmf-common schema in https://github.com/hdmf-dev/hdmf-common-schema/issues/4 , change electrode table column dataset types from `ascii` to `text`. I believe this is backwards compatible, since `text` includes `ascii`.

This change removes all remaining ASCII from the NWB schema.