### PR TITLE
Update specification_language_description.rst

### DIFF
--- a/docs/language/source/specification_language_description.rst
+++ b/docs/language/source/specification_language_description.rst
@@ -435,6 +435,7 @@ See :numref:`sec-link-spec` for details.
     - doc: Link to target type
       name: link name
       target_type: type of target
+      quantity: optional number of links allowed
     - ...
 
 


### PR DESCRIPTION
[quantity is an allowable field for links](https://schema-language.readthedocs.io/en/latest/specification_language_description.html#id12), but it was not in the code block