### PR TITLE
Fix misaligned table

### DIFF
--- a/docs/storage/source/storage_hdf5.rst
+++ b/docs/storage/source/storage_hdf5.rst
@@ -158,7 +158,7 @@ The mappings of data types is as follows
     +--------------------------+----------------------------------+----------------+
     | ``dtype`` **spec value** | **storage type**                 | **size**       |
     +--------------------------+----------------------------------+----------------+
-    |  * "float"               | single precision floating point  | 32 bit        |
+    |  * "float"               | single precision floating point  | 32 bit         |
     |  * "float32"             |                                  |                |
     +--------------------------+----------------------------------+----------------+
     |  * "double"              | double precision floating point  | 64 bit         |


### PR DESCRIPTION
The data types table is misaligned, preventing it from appearing in the storage documentation. This PR fixes that.