### PR TITLE
Reorder requirements-doc.txt to fix pynwb-hdmf dependency problem

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,2 +1,2 @@
-hdmf-docutils
 pynwb
+hdmf-docutils


### PR DESCRIPTION
By pip installing PyNWB before hdmf-docutils, the pinned version of HDMF that is compatible with PyNWB should be installed instead of the latest incompatible version of HDMF (installed by hdmf-docutils).

Fixes #397.