### PR TITLE
Add new type FocalDepthImage, clean up retinotopy.yaml

### DIFF
--- a/core/nwb.retinotopy.yaml
+++ b/core/nwb.retinotopy.yaml
@@ -41,6 +41,7 @@ groups:
     neurodata_type_inc: FocalDepthImage
     doc: 'Grayscale image taken with same settings/parameters (e.g., focal depth,
       wavelength) as data collection. Array format: [rows][columns].'
+    quantity: '?'
   - name: vasculature_image
     neurodata_type_inc: RetinotopyImage
     doc: 'Grayscale anatomical image of cortical surface. Array structure: [rows][columns]'

--- a/core/nwb.retinotopy.yaml
+++ b/core/nwb.retinotopy.yaml
@@ -5,6 +5,9 @@ groups:
   doc: 'Intrinsic signal optical imaging or widefield imaging for measuring retinotopy.
     Stores orthogonal maps (e.g., altitude/azimuth; radius/theta) of responses to
     specific stimuli and a combined polarity map from which to identify visual areas.
+    This group does not store the raw responses imaged during retinotopic mapping or the
+    stimuli presented, but rather the resulting phase and power maps after applying a Fourier
+    transform on the averaged responses.
     NOTE: for data consistency, all images and arrays are stored in the format [row][column]
     and [row, col], which equates to [y][x]. Field of view and dimension arrays may
     appear backward (i.e., y before x).'
@@ -32,7 +35,7 @@ groups:
   - name: axis_descriptions
     dtype: text
     dims:
-    - num_axes
+    - axis_1, axis_2
     shape:
     - 2
     doc: Two-element array describing the contents of the two response axis fields.
@@ -61,7 +64,7 @@ datasets:
   - name: dimension
     dtype: int32
     dims:
-    - row_col
+    - num_rows, num_cols
     shape:
     - 2
     doc: 'Number of rows and columns in the image. NOTE: row, column representation
@@ -69,7 +72,7 @@ datasets:
   - name: field_of_view
     dtype: float32
     dims:
-    - row_col
+    - height, width
     shape:
     - 2
     doc: Size of viewing area, in meters.
@@ -94,7 +97,7 @@ datasets:
   - name: dimension
     dtype: int32
     dims:
-    - row_col
+    - num_rows, num_cols
     shape:
     - 2
     doc: 'Number of rows and columns in the image. NOTE: row, column representation
@@ -102,7 +105,7 @@ datasets:
   - name: field_of_view
     dtype: float32
     dims:
-    - row_col
+    - height, width
     shape:
     - 2
     doc: Size of viewing area, in meters.

--- a/core/nwb.retinotopy.yaml
+++ b/core/nwb.retinotopy.yaml
@@ -14,7 +14,7 @@ groups:
     doc: Phase response to stimulus on the first measured axis.
   - name: axis_1_power_map
     neurodata_type_inc: AxisMap
-    doc: Power response on the first measured axis. Response is scaled so 0.0 is no
+    doc: Power response to stimulus on the first measured axis. Response is scaled so 0.0 is no
       power in the response and 1.0 is maximum relative power.
     quantity: '?'
   - name: axis_2_phase_map
@@ -22,11 +22,13 @@ groups:
     doc: Phase response to stimulus on the second measured axis.
   - name: axis_2_power_map
     neurodata_type_inc: AxisMap
+    doc: Power response to stimulus on the second measured axis. Response is scaled so 0.0 is no
+      power in the response and 1.0 is maximum relative power.
     quantity: '?'
-    doc: Power response to stimulus on the second measured axis.
   - name: sign_map
     neurodata_type_inc: RetinotopyMap
     doc: Sine of the angle between the direction of the gradient in axis_1 and axis_2.
+    quantity: '?'
   - name: axis_descriptions
     dtype: text
     dims:
@@ -34,18 +36,14 @@ groups:
     shape:
     - 2
     doc: Two-element array describing the contents of the two response axis fields.
-      Description should be something like ['altitude', 'azimuth'] or '['radius', 'theta'].
+      Description should be something like ['altitude', 'azimuth'] or ['radius', 'theta'].
   - name: focal_depth_image
-    neurodata_type_inc: RetinotopyImage
-    doc: 'Gray-scale image taken with same settings/parameters (e.g., focal depth,
+    neurodata_type_inc: FocalDepthImage
+    doc: 'Grayscale image taken with same settings/parameters (e.g., focal depth,
       wavelength) as data collection. Array format: [rows][columns].'
-    attributes:
-    - name: focal_depth
-      dtype: float32
-      doc: Focal depth offset, in meters.
   - name: vasculature_image
     neurodata_type_inc: RetinotopyImage
-    doc: 'Gray-scale anatomical image of cortical surface. Array structure: [rows][columns]'
+    doc: 'Grayscale anatomical image of cortical surface. Array structure: [rows][columns]'
 
 datasets:
 - neurodata_type_def: RetinotopyMap
@@ -77,22 +75,16 @@ datasets:
 
 - neurodata_type_def: AxisMap
   neurodata_type_inc: RetinotopyMap
-  dtype: float32
-  dims:
-  - num_rows
-  - num_cols
-  shape:
-  - null
-  - null
-  doc: Abstract two-dimensional map of responses to stimuli along a single response axis (e.g. eccentricity)
+  doc: Abstract two-dimensional map of responses to stimuli along a single response axis (e.g., altitude)
   attributes:
   - name: unit
     dtype: text
     doc: Unit that axis data is stored in (e.g., degrees).
+
 - neurodata_type_def: RetinotopyImage
   neurodata_type_inc: GrayscaleImage
   dtype: uint16
-  doc: 'Gray-scale image related to retinotopic mapping. Array structure: [num_rows][num_columns]'
+  doc: 'Grayscale image related to retinotopic mapping. Array structure: [num_rows][num_columns]'
   attributes:
   - name: bits_per_pixel
     dtype: int32
@@ -115,4 +107,12 @@ datasets:
     doc: Size of viewing area, in meters.
   - name: format
     dtype: text
-    doc: Format of image. Right now only 'raw' is supported.
+    doc: Format of image. Right now, only 'raw' is supported.
+
+- neurodata_type_def: FocalDepthImage
+  neurodata_type_inc: RetinotopyImage
+  doc: Grayscale image taken with the same settings/parameters (e.g., focal depth, wavelength) as data collection.
+  attributes:
+  - name: focal_depth
+    dtype: float32
+    doc: Focal depth offset, in meters.


### PR DESCRIPTION
After discussion with @ajtritt , it is recommended not to add a required attribute (`focal_depth`) to an instance of neurodata_type (`RetinotopyImage`) without creating a new neurodata type. To get around that, here we create a new neurodata type to store the focal depth image.