### PR TITLE
Revert changes to retinotopy.yaml

### DIFF
--- a/core/nwb.retinotopy.yaml
+++ b/core/nwb.retinotopy.yaml
@@ -147,6 +147,7 @@ groups:
     - null
     doc: 'Gray-scale image taken with same settings/parameters (e.g., focal depth,
       wavelength) as data collection. Array format: [rows][columns].'
+    quantity: '?'
     attributes:
     - name: bits_per_pixel
       dtype: int32
@@ -182,6 +183,7 @@ groups:
     - null
     - null
     doc: Sine of the angle between the direction of the gradient in axis_1 and axis_2.
+    quantity: '?'
     attributes:
     - name: dimension
       dtype: int32

--- a/core/nwb.retinotopy.yaml
+++ b/core/nwb.retinotopy.yaml
@@ -5,114 +5,225 @@ groups:
   doc: 'Intrinsic signal optical imaging or widefield imaging for measuring retinotopy.
     Stores orthogonal maps (e.g., altitude/azimuth; radius/theta) of responses to
     specific stimuli and a combined polarity map from which to identify visual areas.
-    NOTE: for data consistency, all images and arrays are stored in the format [row][column]
+    Note: for data consistency, all images and arrays are stored in the format [row][column]
     and [row, col], which equates to [y][x]. Field of view and dimension arrays may
     appear backward (i.e., y before x).'
   datasets:
   - name: axis_1_phase_map
-    neurodata_type_inc: AxisMap
+    dtype: float32
+    dims:
+    - num_rows
+    - num_cols
+    shape:
+    - null
+    - null
     doc: Phase response to stimulus on the first measured axis.
+    attributes:
+    - name: dimension
+      dtype: int32
+      dims:
+      - row_col
+      shape:
+      - null
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+    - name: field_of_view
+      dtype: float
+      dims:
+      - row|column
+      shape:
+      - null
+      doc: Size of viewing area, in meters.
+    - name: unit
+      dtype: text
+      doc: Unit that axis data is stored in (e.g., degrees).
   - name: axis_1_power_map
-    neurodata_type_inc: AxisMap
+    dtype: float32
+    dims:
+    - num_rows
+    - num_cols
+    shape:
+    - null
+    - null
     doc: Power response on the first measured axis. Response is scaled so 0.0 is no
       power in the response and 1.0 is maximum relative power.
     quantity: '?'
+    attributes:
+    - name: dimension
+      dtype: int32
+      dims:
+      - row_col
+      shape:
+      - null
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+    - name: field_of_view
+      dtype: float
+      dims:
+      - row_col
+      shape:
+      - null
+      doc: Size of viewing area, in meters.
+    - name: unit
+      dtype: text
+      doc: Unit that axis data is stored in (e.g., degrees).
   - name: axis_2_phase_map
-    neurodata_type_inc: AxisMap
+    dtype: float32
+    dims:
+    - num_rows
+    - num_cols
+    shape:
+    - null
+    - null
     doc: Phase response to stimulus on the second measured axis.
+    attributes:
+    - name: dimension
+      dtype: int32
+      dims:
+      - row_col
+      shape:
+      - null
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+    - name: field_of_view
+      dtype: float
+      dims:
+      - row_col
+      shape:
+      - null
+      doc: Size of viewing area, in meters.
+    - name: unit
+      dtype: text
+      doc: Unit that axis data is stored in (e.g., degrees).
   - name: axis_2_power_map
-    neurodata_type_inc: AxisMap
+    dtype: float32
+    dims:
+    - num_rows
+    - num_cols
+    shape:
+    - null
+    - null
+    doc: Power response on the second measured axis. Response is scaled so 0.0 is
+      no power in the response and 1.0 is maximum relative power.
     quantity: '?'
-    doc: Power response to stimulus on the second measured axis.
-  - name: sign_map
-    neurodata_type_inc: RetinotopyMap
-    doc: Sine of the angle between the direction of the gradient in axis_1 and axis_2.
+    attributes:
+    - name: dimension
+      dtype: int32
+      dims:
+      - row_col
+      shape:
+      - null
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+    - name: field_of_view
+      dtype: float
+      dims:
+      - row_col
+      shape:
+      - null
+      doc: Size of viewing area, in meters.
+    - name: unit
+      dtype: text
+      doc: Unit that axis data is stored in (e.g., degrees).
   - name: axis_descriptions
     dtype: text
     dims:
-    - num_axes
+    - names
     shape:
     - 2
     doc: Two-element array describing the contents of the two response axis fields.
-      Description should be something like ['altitude', 'azimuth'] or '['radius', 'theta'].
+      Description should be something like ['altitude', 'azimuth'] or '['radius',
+      'theta'].
   - name: focal_depth_image
-    neurodata_type_inc: RetinotopyImage
+    dtype: uint16
+    dims:
+    - num_rows
+    - num_cols
+    shape:
+    - null
+    - null
     doc: 'Gray-scale image taken with same settings/parameters (e.g., focal depth,
       wavelength) as data collection. Array format: [rows][columns].'
     attributes:
+    - name: bits_per_pixel
+      dtype: int32
+      doc: Number of bits used to represent each value. This is necessary to determine
+        maximum (white) pixel value.
+    - name: dimension
+      dtype: int32
+      dims:
+      - row_col
+      shape:
+      - null
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+    - name: field_of_view
+      dtype: float
+      dims:
+      - row_col
+      shape:
+      - null
+      doc: Size of viewing area, in meters.
     - name: focal_depth
-      dtype: float32
+      dtype: float
       doc: Focal depth offset, in meters.
+    - name: format
+      dtype: text
+      doc: Format of image. Right now only 'raw' is supported.
+  - name: sign_map
+    dtype: float32
+    dims:
+    - num_rows
+    - num_cols
+    shape:
+    - null
+    - null
+    doc: Sine of the angle between the direction of the gradient in axis_1 and axis_2.
+    attributes:
+    - name: dimension
+      dtype: int32
+      dims:
+      - row_col
+      shape:
+      - null
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+    - name: field_of_view
+      dtype: float
+      dims:
+      - row_col
+      shape:
+      - null
+      doc: Size of viewing area, in meters.
   - name: vasculature_image
-    neurodata_type_inc: RetinotopyImage
+    dtype: uint16
+    dims:
+    - num_rows
+    - num_cols
+    shape:
+    - null
+    - null
     doc: 'Gray-scale anatomical image of cortical surface. Array structure: [rows][columns]'
-
-datasets:
-- neurodata_type_def: RetinotopyMap
-  neurodata_type_inc: NWBData
-  dtype: float32
-  dims:
-  - num_rows
-  - num_cols
-  shape:
-  - null
-  - null
-  doc: 'Abstract two-dimensional map of responses. Array structure: [num_rows][num_columns]'
-  attributes:
-  - name: dimension
-    dtype: int32
-    dims:
-    - row_col
-    shape:
-    - 2
-    doc: 'Number of rows and columns in the image. NOTE: row, column representation
-      is equivalent to height, width.'
-  - name: field_of_view
-    dtype: float32
-    dims:
-    - row_col
-    shape:
-    - 2
-    doc: Size of viewing area, in meters.
-
-- neurodata_type_def: AxisMap
-  neurodata_type_inc: RetinotopyMap
-  dtype: float32
-  dims:
-  - num_rows
-  - num_cols
-  shape:
-  - null
-  - null
-  doc: Abstract two-dimensional map of responses to stimuli along a single response axis (e.g. eccentricity)
-  attributes:
-  - name: unit
-    dtype: text
-    doc: Unit that axis data is stored in (e.g., degrees).
-- neurodata_type_def: RetinotopyImage
-  neurodata_type_inc: GrayscaleImage
-  dtype: uint16
-  doc: 'Gray-scale image related to retinotopic mapping. Array structure: [num_rows][num_columns]'
-  attributes:
-  - name: bits_per_pixel
-    dtype: int32
-    doc: Number of bits used to represent each value. This is necessary to determine
-      maximum (white) pixel value.
-  - name: dimension
-    dtype: int32
-    dims:
-    - row_col
-    shape:
-    - 2
-    doc: 'Number of rows and columns in the image. NOTE: row, column representation
-      is equivalent to height, width.'
-  - name: field_of_view
-    dtype: float32
-    dims:
-    - row_col
-    shape:
-    - 2
-    doc: Size of viewing area, in meters.
-  - name: format
-    dtype: text
-    doc: Format of image. Right now only 'raw' is supported.
+    attributes:
+    - name: bits_per_pixel
+      dtype: int32
+      doc: Number of bits used to represent each value. This is necessary to determine
+        maximum (white) pixel value
+    - name: dimension
+      dtype: int32
+      dims:
+      - row_col
+      shape:
+      - null
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+    - name: field_of_view
+      dtype: float
+      dims:
+      - row_col
+      shape:
+      - null
+      doc: Size of viewing area, in meters.
+    - name: format
+      dtype: text
+      doc: Format of image. Right now only 'raw' is supported.

--- a/core/nwb.retinotopy.yaml
+++ b/core/nwb.retinotopy.yaml
@@ -5,6 +5,9 @@ groups:
   doc: 'Intrinsic signal optical imaging or widefield imaging for measuring retinotopy.
     Stores orthogonal maps (e.g., altitude/azimuth; radius/theta) of responses to
     specific stimuli and a combined polarity map from which to identify visual areas.
+    This group does not store the raw responses imaged during retinotopic mapping or the
+    stimuli presented, but rather the resulting phase and power maps after applying a Fourier
+    transform on the averaged responses.
     Note: for data consistency, all images and arrays are stored in the format [row][column]
     and [row, col], which equates to [y][x]. Field of view and dimension arrays may
     appear backward (i.e., y before x).'
@@ -22,17 +25,17 @@ groups:
     - name: dimension
       dtype: int32
       dims:
-      - row_col
+      - num_rows, num_cols
       shape:
-      - null
+      - 2
       doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
+        is equivalent to height, width.'
     - name: field_of_view
-      dtype: float
+      dtype: float32
       dims:
-      - row|column
+      - height, width
       shape:
-      - null
+      - 2
       doc: Size of viewing area, in meters.
     - name: unit
       dtype: text
@@ -52,17 +55,17 @@ groups:
     - name: dimension
       dtype: int32
       dims:
-      - row_col
+      - num_rows, num_cols
       shape:
-      - null
+      - 2
       doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
+        is equivalent to height, width.'
     - name: field_of_view
-      dtype: float
+      dtype: float32
       dims:
-      - row_col
+      - height, width
       shape:
-      - null
+      - 2
       doc: Size of viewing area, in meters.
     - name: unit
       dtype: text
@@ -80,17 +83,17 @@ groups:
     - name: dimension
       dtype: int32
       dims:
-      - row_col
+      - num_rows, num_cols
       shape:
-      - null
+      - 2
       doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
+        is equivalent to height, width.'
     - name: field_of_view
-      dtype: float
+      dtype: float32
       dims:
-      - row_col
+      - height, width
       shape:
-      - null
+      - 2
       doc: Size of viewing area, in meters.
     - name: unit
       dtype: text
@@ -110,17 +113,17 @@ groups:
     - name: dimension
       dtype: int32
       dims:
-      - row_col
+      - num_rows, num_cols
       shape:
-      - null
+      - 2
       doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
+        is equivalent to height, width.'
     - name: field_of_view
-      dtype: float
+      dtype: float32
       dims:
-      - row_col
+      - height, width
       shape:
-      - null
+      - 2
       doc: Size of viewing area, in meters.
     - name: unit
       dtype: text
@@ -128,7 +131,7 @@ groups:
   - name: axis_descriptions
     dtype: text
     dims:
-    - names
+    - axis_1, axis_2
     shape:
     - 2
     doc: Two-element array describing the contents of the two response axis fields.
@@ -152,20 +155,20 @@ groups:
     - name: dimension
       dtype: int32
       dims:
-      - row_col
+      - num_rows, num_cols
       shape:
-      - null
+      - 2
       doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
+        is equivalent to height, width.'
     - name: field_of_view
-      dtype: float
+      dtype: float32
       dims:
-      - row_col
+      - height, width
       shape:
-      - null
+      - 2
       doc: Size of viewing area, in meters.
     - name: focal_depth
-      dtype: float
+      dtype: float32
       doc: Focal depth offset, in meters.
     - name: format
       dtype: text
@@ -183,17 +186,17 @@ groups:
     - name: dimension
       dtype: int32
       dims:
-      - row_col
+      - num_rows, num_cols
       shape:
-      - null
+      - 2
       doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
+        is equivalent to height, width.'
     - name: field_of_view
-      dtype: float
+      dtype: float32
       dims:
-      - row_col
+      - height, width
       shape:
-      - null
+      - 2
       doc: Size of viewing area, in meters.
   - name: vasculature_image
     dtype: uint16
@@ -212,17 +215,17 @@ groups:
     - name: dimension
       dtype: int32
       dims:
-      - row_col
+      - num_rows, num_cols
       shape:
-      - null
+      - 2
       doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
+        is equivalent to height, width.'
     - name: field_of_view
-      dtype: float
+      dtype: float32
       dims:
-      - row_col
+      - height, width
       shape:
-      - null
+      - 2
       doc: Size of viewing area, in meters.
     - name: format
       dtype: text


### PR DESCRIPTION
1) Revert the changes that were made in https://github.com/NeurodataWithoutBorders/nwb-schema/pull/304 that reduced redundancy in the imaging retinotopy schema by way of introducing new neurodata types. These new types create a challenge for the APIs to read files created with an earlier version of `ImagingRetinotopy` that do not have the core spec cached. For the time being, until the API can be updated appropriately, these changes will be put on hold. 

2) Apply some of the non-breaking changes from #304 in specifying shape, and clarifying docs, dtype, and dims

3) Make `sign_map` and `focal_depth_image` datasets optional -- see #407