### PR TITLE
Extracted nested type definitions to the root of the yaml file

### DIFF
--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -93,14 +93,9 @@ groups:
       doc: Any one-off tables
       quantity: '*'
     datasets:
-    - neurodata_type_def: ScratchData
-      neurodata_type_inc: NWBData
+    - neurodata_type_inc: ScratchData
       doc: Any one-off datasets
       quantity: '*'
-      attributes:
-      - name: notes
-        doc: 'Any notes the user has about the dataset being stored'
-        dtype: text
   - name: processing
     doc: "The home for ProcessingModules. These modules perform intermediate analysis\
       \ of data that is necessary to perform before scientific analysis. Examples\
@@ -248,8 +243,7 @@ groups:
         date made, injection location, volume, etc.
       quantity: '?'
     groups:
-    - neurodata_type_def: LabMetaData
-      neurodata_type_inc: NWBContainer
+    - neurodata_type_inc: LabMetaData
       doc: Place-holder than can be extended so that lab-specific meta-data can be
         placed in /general.
       quantity: '*'
@@ -261,46 +255,10 @@ groups:
       - neurodata_type_inc: Device
         doc: Data acquisition devices.
         quantity: '*'
-    - neurodata_type_def: Subject
-      neurodata_type_inc: NWBContainer
-      name: subject
+    - name: subject
+      neurodata_type_inc: Subject
       doc: Information about the animal or person from which the data was measured.
       quantity: '?'
-      datasets:
-      - name: age
-        dtype: text
-        doc: Age of subject. Can be supplied instead of 'date_of_birth'.
-        quantity: '?'
-      - name: date_of_birth
-        dtype: isodatetime
-        doc: Date of birth of subject. Can be supplied instead of 'age'.
-        quantity: '?'
-      - name: description
-        dtype: text
-        doc: Description of subject and where subject came from (e.g., breeder, if
-          animal).
-        quantity: '?'
-      - name: genotype
-        dtype: text
-        doc: Genetic strain. If absent, assume Wild Type (WT).
-        quantity: '?'
-      - name: sex
-        dtype: text
-        doc: Gender of subject.
-        quantity: '?'
-      - name: species
-        dtype: text
-        doc: Species of subject.
-        quantity: '?'
-      - name: subject_id
-        dtype: text
-        doc: ID of animal/person used/participating in experiment (lab convention).
-        quantity: '?'
-      - name: weight
-        dtype: text
-        doc: Weight at time of experiment, at time of surgery and at other important
-          times.
-        quantity: '?'
     - name: extracellular_ephys
       doc: Metadata related to extracellular electrophysiology.
       quantity: '?'
@@ -427,3 +385,55 @@ groups:
     neurodata_type_inc: Units
     doc: Data about sorted spike units.
     quantity: '?'
+
+- neurodata_type_def: LabMetaData
+  neurodata_type_inc: NWBContainer
+  doc: Lab-specific meta-data.
+
+- neurodata_type_def: Subject
+  neurodata_type_inc: NWBContainer
+  doc: Information about the animal or person from which the data was measured.
+  datasets:
+  - name: age
+    dtype: text
+    doc: Age of subject. Can be supplied instead of 'date_of_birth'.
+    quantity: '?'
+  - name: date_of_birth
+    dtype: isodatetime
+    doc: Date of birth of subject. Can be supplied instead of 'age'.
+    quantity: '?'
+  - name: description
+    dtype: text
+    doc: Description of subject and where subject came from (e.g., breeder, if
+      animal).
+    quantity: '?'
+  - name: genotype
+    dtype: text
+    doc: Genetic strain. If absent, assume Wild Type (WT).
+    quantity: '?'
+  - name: sex
+    dtype: text
+    doc: Gender of subject.
+    quantity: '?'
+  - name: species
+    dtype: text
+    doc: Species of subject.
+    quantity: '?'
+  - name: subject_id
+    dtype: text
+    doc: ID of animal/person used/participating in experiment (lab convention).
+    quantity: '?'
+  - name: weight
+    dtype: text
+    doc: Weight at time of experiment, at time of surgery and at other important
+      times.
+    quantity: '?'
+
+datasets:
+- neurodata_type_def: ScratchData
+  neurodata_type_inc: NWBData
+  doc: Any one-off datasets
+  attributes:
+  - name: notes
+    doc: 'Any notes the user has about the dataset being stored'
+    dtype: text

--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -83,85 +83,88 @@ groups:
     is allowed to change with time, a new imaging plane (or module) is required and
     ROI names should remain consistent between them.
   groups:
-  - neurodata_type_def: PlaneSegmentation
-    neurodata_type_inc: DynamicTable
+  - neurodata_type_inc: PlaneSegmentation
     doc: Results from image segmentation of a specific imaging plane.
     quantity: '+'
-    datasets:
-    - name: image_mask
-      neurodata_type_inc: VectorData
-      dims:
-      - - num_roi
-        - num_x
-        - num_y
-      - - num_roi
-        - num_x
-        - num_y
-        - num_z
-      shape:
-      - - null
-        - null
-        - null
-      - - null
-        - null
-        - null
-        - null
-      doc: ROI masks for each ROI. Each image mask is the size of the original imaging
-        plane (or volume) and members of the ROI are finite non-zero.
-      quantity: '?'
-    - name: pixel_mask_index
-      neurodata_type_inc: VectorIndex
-      doc: Index into pixel_mask.
-      quantity: '?'
-    - name: pixel_mask
-      neurodata_type_inc: VectorData
-      dtype:
-      - name: x
-        dtype: uint32
-        doc: Pixel x-coordinate.
-      - name: y
-        dtype: uint32
-        doc: Pixel y-coordinate.
-      - name: weight
-        dtype: float32
-        doc: Weight of the pixel.
-      doc: 'Pixel masks for each ROI: a list of indices and weights for the ROI. Pixel
-        masks are concatenated and parsing of this dataset is maintained by the PlaneSegmentation'
-      quantity: '?'
-    - name: voxel_mask_index
-      neurodata_type_inc: VectorIndex
-      doc: Index into voxel_mask.
-      quantity: '?'
-    - name: voxel_mask
-      neurodata_type_inc: VectorData
-      dtype:
-      - name: x
-        dtype: uint32
-        doc: Voxel x-coordinate.
-      - name: y
-        dtype: uint32
-        doc: Voxel y-coordinate.
-      - name: z
-        dtype: uint32
-        doc: Voxel z-coordinate.
-      - name: weight
-        dtype: float32
-        doc: Weight of the voxel.
-      doc: 'Voxel masks for each ROI: a list of indices and weights for the ROI. Voxel
-        masks are concatenated and parsing of this dataset is maintained by the PlaneSegmentation'
-      quantity: '?'
+
+- neurodata_type_def: PlaneSegmentation
+  neurodata_type_inc: DynamicTable
+  doc: Results from image segmentation of a specific imaging plane.
+  datasets:
+  - name: image_mask
+    neurodata_type_inc: VectorData
+    dims:
+    - - num_roi
+      - num_x
+      - num_y
+    - - num_roi
+      - num_x
+      - num_y
+      - num_z
+    shape:
+    - - null
+      - null
+      - null
+    - - null
+      - null
+      - null
+      - null
+    doc: ROI masks for each ROI. Each image mask is the size of the original imaging
+      plane (or volume) and members of the ROI are finite non-zero.
+    quantity: '?'
+  - name: pixel_mask_index
+    neurodata_type_inc: VectorIndex
+    doc: Index into pixel_mask.
+    quantity: '?'
+  - name: pixel_mask
+    neurodata_type_inc: VectorData
+    dtype:
+    - name: x
+      dtype: uint32
+      doc: Pixel x-coordinate.
+    - name: y
+      dtype: uint32
+      doc: Pixel y-coordinate.
+    - name: weight
+      dtype: float32
+      doc: Weight of the pixel.
+    doc: 'Pixel masks for each ROI: a list of indices and weights for the ROI. Pixel
+      masks are concatenated and parsing of this dataset is maintained by the PlaneSegmentation'
+    quantity: '?'
+  - name: voxel_mask_index
+    neurodata_type_inc: VectorIndex
+    doc: Index into voxel_mask.
+    quantity: '?'
+  - name: voxel_mask
+    neurodata_type_inc: VectorData
+    dtype:
+    - name: x
+      dtype: uint32
+      doc: Voxel x-coordinate.
+    - name: y
+      dtype: uint32
+      doc: Voxel y-coordinate.
+    - name: z
+      dtype: uint32
+      doc: Voxel z-coordinate.
+    - name: weight
+      dtype: float32
+      doc: Weight of the voxel.
+    doc: 'Voxel masks for each ROI: a list of indices and weights for the ROI. Voxel
+      masks are concatenated and parsing of this dataset is maintained by the PlaneSegmentation'
+    quantity: '?'
+  groups:
+  - name: reference_images
+    doc: Image stacks that the segmentation masks apply to.
     groups:
-    - name: reference_images
-      doc: Image stacks that the segmentation masks apply to.
-      groups:
-      - neurodata_type_inc: ImageSeries
-        doc: One or more image stacks that the masks apply to (can be one-element
-          stack).
-        quantity: '*'
-    links:
-    - name: imaging_plane
-      target_type: ImagingPlane
-      doc: Link to ImagingPlane object from which this data was generated.
+    - neurodata_type_inc: ImageSeries
+      doc: One or more image stacks that the masks apply to (can be one-element
+        stack).
+      quantity: '*'
+  links:
+  - name: imaging_plane
+    target_type: ImagingPlane
+    doc: Link to ImagingPlane object from which this data was generated.
 
 - neurodata_type_def: ImagingPlane
   neurodata_type_inc: NWBContainer
@@ -274,21 +277,24 @@ groups:
       rightward). Third dimension corresponds to dorsal-ventral axis (larger index = more ventral)."
     quantity: '?'
   groups:
-  - neurodata_type_def: OpticalChannel
-    neurodata_type_inc: NWBContainer
+  - neurodata_type_inc: OpticalChannel
     doc: An optical channel used to record from an imaging plane.
     quantity: '+'
-    datasets:
-    - name: description
-      dtype: text
-      doc: Description or other notes about the channel.
-    - name: emission_lambda
-      dtype: float32
-      doc: Emission wavelength for channel, in nm.
   links:
   - name: device
     target_type: Device
     doc: Link to the Device object that was used to record from this electrode.
+
+- neurodata_type_def: OpticalChannel
+  neurodata_type_inc: NWBContainer
+  doc: An optical channel used to record from an imaging plane.
+  datasets:
+  - name: description
+    dtype: text
+    doc: Description or other notes about the channel.
+  - name: emission_lambda
+    dtype: float32
+    doc: Emission wavelength for channel, in nm.
 
 - neurodata_type_def: MotionCorrection
   neurodata_type_inc: NWBDataInterface
@@ -297,19 +303,22 @@ groups:
     system, to account for movement and drift between frames. Note: each frame at
     each point in time is assumed to be 2-D (has only x & y dimensions).'
   groups:
-  - neurodata_type_def: CorrectedImageStack
-    neurodata_type_inc: NWBDataInterface
+  - neurodata_type_inc: CorrectedImageStack
     doc: Reuslts from motion correction of an image stack.
     quantity: '+'
-    groups:
-    - name: corrected
-      neurodata_type_inc: ImageSeries
-      doc: Image stack with frames shifted to the common coordinates.
-    - name: xy_translation
-      neurodata_type_inc: TimeSeries
-      doc: Stores the x,y delta necessary to align each frame to the common coordinates,
-        for example, to align each frame to a reference image.
-    links:
-    - name: original
-      target_type: ImageSeries
-      doc: Link to ImageSeries object that is being registered.
+
+- neurodata_type_def: CorrectedImageStack
+  neurodata_type_inc: NWBDataInterface
+  doc: Reuslts from motion correction of an image stack.
+  groups:
+  - name: corrected
+    neurodata_type_inc: ImageSeries
+    doc: Image stack with frames shifted to the common coordinates.
+  - name: xy_translation
+    neurodata_type_inc: TimeSeries
+    doc: Stores the x,y delta necessary to align each frame to the common coordinates,
+      for example, to align each frame to a reference image.
+  links:
+  - name: original
+    target_type: ImageSeries
+    doc: Link to ImageSeries object that is being registered.


### PR DESCRIPTION
See https://github.com/hdmf-dev/hdmf/issues/316 for reasoning. 

This does not change the schema functionally but reorganizes the type definitions to remove type definitions that are nested within another type definition. Now all types are defined at the root of the yaml file.