### PR TITLE
make ImagingPlane.imaging_rate optional

### DIFF
--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -180,7 +180,9 @@ groups:
     doc: Excitation wavelength, in nm.
   - name: imaging_rate
     dtype: float32
-    doc: Rate that images are acquired, in Hz.
+    doc: Rate that images are acquired, in Hz. If the corresponding TimeSeries is present, the rate should be stored
+    there instead.
+    quantity: '?'
   - name: indicator
     dtype: text
     doc: Calcium indicator.

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -1,6 +1,10 @@
 Release Notes
 =============
 
+2.2.3 (Upcoming)
+----------------
+- Make `ImagingPlane.imaging_rate` optional
+
 2.2.2 (March 2, 2020)
 ---------------------
 


### PR DESCRIPTION
fix #428

- [x] make schema change
- [x] put change in release notes
- [x] make pynwb change (see https://github.com/NeurodataWithoutBorders/pynwb/pull/1221)