### PR TITLE
Update version string to 2.2.3

### DIFF
--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -7,7 +7,7 @@ groups:
   attributes:
   - name: nwb_version
     dtype: text
-    value: 2.2.2
+    value: 2.2.3
     doc: File version string. Use semantic versioning, e.g. 1.2.1. This will be the
       name of the format with trailing major, minor and patch numbers.
   datasets:

--- a/core/nwb.namespace.yaml
+++ b/core/nwb.namespace.yaml
@@ -57,4 +57,4 @@ namespaces:
   - doc: This source module contains neurodata_type for retinotopy data.
     source: nwb.retinotopy.yaml
     title: Retinotopy
-  version: 2.2.2
+  version: 2.2.3

--- a/docs/format/source/conf.py
+++ b/docs/format/source/conf.py
@@ -83,7 +83,7 @@ copyright = u'2017-2020, Neurodata Without Borders'
 # built documents.
 #
 # The short X.Y version.
-version = 'v2.2.2'
+version = 'v2.2.3'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -4,9 +4,9 @@ Release Notes
 2.2.3 (April 13, 2020)
 ----------------------
 
-- Move nested type definitions to root of YAML files. This does not functionally change the schema.
+- Move nested type definitions to root of YAML files. This does not functionally change the schema but simplifies parsing of the schema and extensions by APIs.
+- Make `ImagingPlane.imaging_rate` optional to handle cases where an imaging plane is associated with multiple time series with different rates.
 - Add release process documentation.
-- Make `ImagingPlane.imaging_rate` optional
 
 2.2.2 (March 2, 2020)
 ---------------------

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+2.2.3 (April 13, 2020)
+----------------------
+
+- Move nested type definitions to root of YAML files. This does not functionally change the schema.
+- Add release process documentation.
+
 2.2.2 (March 2, 2020)
 ---------------------
 


### PR DESCRIPTION
This will be the last PR before making a release for NWB version 2.2.3.

- [x] Update requirements versions as needed
- [x] Update legal file dates and information in Legal.txt, license.txt, README.rst, conf.py, and any other locations as needed
- [x] Update README as needed
- [x] Update conf.py as needed
- [x] Update hdmf-common-schema submodule as needed. Check the version number manually.
- [x] Choose an appropriate new version number
- [x] Update nwb.namespace.yaml, nwb.file.yaml, and conf.py with the latest version string
- [x] Update release notes and relevant docs
- [x] Test docs locally (`make fulldoc`)
- [x] Push changes to a new PR and make sure all PRs to be included in this release have been merged
- [x] Check that the readthedocs build for this PR succeeds (build latest to get the new branch, then activate and build docs for new branch):     https://readthedocs.org/projects/nwb-schema/builds/

After:
- Create release on GitHub releases page with release notes
- Check that readthedocs stable build succeeds
- Deactivate readthedocs build for this PR 