### PR TITLE
Fix typo in nwb.ophys.yaml and create version 2.2.4

### DIFF
--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -7,7 +7,7 @@ groups:
   attributes:
   - name: nwb_version
     dtype: text
-    value: 2.2.3
+    value: 2.2.4
     doc: File version string. Use semantic versioning, e.g. 1.2.1. This will be the
       name of the format with trailing major, minor and patch numbers.
   datasets:

--- a/core/nwb.namespace.yaml
+++ b/core/nwb.namespace.yaml
@@ -57,4 +57,4 @@ namespaces:
   - doc: This source module contains neurodata_type for retinotopy data.
     source: nwb.retinotopy.yaml
     title: Retinotopy
-  version: 2.2.3
+  version: 2.2.4

--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -181,7 +181,7 @@ groups:
   - name: imaging_rate
     dtype: float32
     doc: Rate that images are acquired, in Hz. If the corresponding TimeSeries is present, the rate should be stored
-    there instead.
+      there instead.
     quantity: '?'
   - name: indicator
     dtype: text

--- a/docs/format/source/conf.py
+++ b/docs/format/source/conf.py
@@ -83,7 +83,7 @@ copyright = u'2017-2020, Neurodata Without Borders'
 # built documents.
 #
 # The short X.Y version.
-version = 'v2.2.3'
+version = 'v2.2.4'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+2.2.4 (April 14, 2020)
+----------------------
+
+- Fix typo in nwb.ophys.yaml that prevents proper parsing of the schema.
+
 2.2.3 (April 13, 2020)
 ----------------------
 


### PR DESCRIPTION
There was a typo (missing indent) in a change committed to version 2.2.3 that prevents the schema from being parsed correctly. This slipped through because I forgot to add a critical step to the checklist below, which is to test the schema with the corresponding branch in PyNWB before making a release.

- [x] Update requirements versions as needed
- [x] Update legal file dates and information in Legal.txt, license.txt, README.rst, conf.py, and any other locations as needed
- [x] Update README as needed
- [x] Update conf.py as needed
- [x] Update hdmf-common-schema submodule as needed. Check the version number manually.
- [x] Choose an appropriate new version number
- [x] Update nwb.namespace.yaml, nwb.file.yaml, and conf.py with the latest version string
- [x] Update release notes and relevant docs
- [x] Test docs locally (`make fulldoc`)
- [x] Push changes to a new PR and make sure all PRs to be included in this release have been merged
- [x] Point PyNWB submodule to this branch in the PyNWB branch corresponding to this schema version and run PyNWB tests
- [x] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and build docs for new branch): https://readthedocs.org/projects/nwb-schema/builds/

After:
- Create release on GitHub releases page with release notes
- Check that readthedocs stable build succeeds
- Deactivate readthedocs build for this PR
- Update PyNWB branch corresponding to this schema version to pull latest nwb-schema and tags and point to latest tag (`cd src/pynwb/nwb-schema/`, `git pull origin dev`, `git fetch --tags`, `git checkout [new_release]`, `cd ../../..`, git add, commit, and push)
