### PR TITLE
storage_hdf5: Use groups instead of dataset in quantity

### DIFF
--- a/docs/storage/source/storage_hdf5.rst
+++ b/docs/storage/source/storage_hdf5.rst
@@ -76,7 +76,7 @@ Groups
     attributes                    HDF5 attributes on the HDF5 group
     links                         HDF5 SoftLinks within the HDF5 group
     linkable                      Not mapped; Stored in schema only
-    quantity                      Not mapped; Number of appearances of the dataset.
+    quantity                      Not mapped; Number of appearances of the group
     neurodata_type                Attribute ``neurodata_type``
     namespace ID                  Attribute ``namespace``
     object ID                     Attribute ``object_id``

--- a/docs/storage/source/storage_hdf5.rst
+++ b/docs/storage/source/storage_hdf5.rst
@@ -99,7 +99,7 @@ Datasets
     dtype                         Data type of the HDF5 dataset (see `dtype mappings`_ table)
     shape                         Shape of the HDF5 dataset if the shape is fixed, otherwise shape defines the maxshape
     dims                          Not mapped
-    attributes                    HDF5 attributes on the HDF5 group
+    attributes                    HDF5 attributes on the HDF5 dataset
     linkable                      Not mapped; Stored in schema only
     quantity                      Not mapped; Number of appearances of the dataset.
     neurodata_type                Attribute ``neurodata_type``

--- a/docs/storage/source/storage_release_notes.rst
+++ b/docs/storage/source/storage_release_notes.rst
@@ -2,6 +2,10 @@
 Release Notes
 =============
 
+NWB Storage v2.1.1
+------------------
+Fix wording in documentation of key mapping tables for group and dataset.
+
 NWB:N - v2.1.0
 --------------
 Added documentation for new NWB key 'object_id' (see also format release notes for NWB 2.1.0: https://nwb-schema.readthedocs.io/en/latest/format_release_notes.html#september-2019).


### PR DESCRIPTION
Broken since 621c2d58 (Updated documentation of the storage,
2017-04-27).