### PR TITLE
Fix dims and shape of ImagingPlane and TwoPhotonSeries datasets

### DIFF
--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -7,7 +7,7 @@ groups:
   attributes:
   - name: nwb_version
     dtype: text
-    value: 2.2.4
+    value: 2.2.5
     doc: File version string. Use semantic versioning, e.g. 1.2.1. This will be the
       name of the format with trailing major, minor and patch numbers.
   datasets:

--- a/core/nwb.namespace.yaml
+++ b/core/nwb.namespace.yaml
@@ -57,4 +57,4 @@ namespaces:
   - doc: This source module contains neurodata_type for retinotopy data.
     source: nwb.retinotopy.yaml
     title: Retinotopy
-  version: 2.2.4
+  version: 2.2.5

--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -17,8 +17,8 @@ groups:
   - name: field_of_view
     dtype: float32
     dims:
-    - width|height
-    - width|height|depth
+    - - width|height
+    - - width|height|depth
     shape:
     - - 2
     - - 3
@@ -232,11 +232,11 @@ groups:
   - name: origin_coords
     dtype: float32
     dims:
-    - x, y
-    - x, y, z
+    - - x, y
+    - - x, y, z
     shape:
-    - 2
-    - 3
+    - - 2
+    - - 3
     doc: Physical location of the first element of the imaging plane (0, 0) for 2-D data or (0, 0, 0) for 3-D data.
       See also reference_frame for what the physical location is relative to (e.g., bregma).
     quantity: '?'
@@ -248,11 +248,11 @@ groups:
   - name: grid_spacing
     dtype: float32
     dims:
-    - x, y
-    - x, y, z
+    - - x, y
+    - - x, y, z
     shape:
-    - 2
-    - 3
+    - - 2
+    - - 3
     doc: Space between pixels in (x, y) or voxels in (x, y, z) directions, in the specified unit.
       Assumes imaging plane is a regular grid. See also reference_frame to interpret the grid.
     quantity: '?'

--- a/docs/format/source/conf.py
+++ b/docs/format/source/conf.py
@@ -36,7 +36,7 @@ def run_doc_autogen(_):
 
 def setup(app):
    app.connect('builder-inited', run_doc_autogen)
-   app.add_stylesheet("theme_overrides.css")  # overrides for wide tables in RTD theme
+   app.add_css_file("theme_overrides.css")  # overrides for wide tables in RTD theme
 
 
 # -- ext settings -----------------------------------------------------

--- a/docs/format/source/conf.py
+++ b/docs/format/source/conf.py
@@ -83,7 +83,7 @@ copyright = u'2017-2020, Neurodata Without Borders'
 # built documents.
 #
 # The short X.Y version.
-version = 'v2.2.4'
+version = 'v2.2.5'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -4,32 +4,33 @@ Release Notes
 2.2.5 (May 29, 2020)
 ----------------------
 
+- Add schema validation CI.
 - Fix incorrect dims and shape for ``ImagingPlane.origin_coords`` and ``ImagingPlane.grid_spacing``, and fix incorrect dims for ``TwoPhotonSeries.field_of_view``.
 
 2.2.4 (April 14, 2020)
 ----------------------
 
-- Fix typo in nwb.ophys.yaml that prevents proper parsing of the schema.
+- Fix typo in ``nwb.ophys.yaml`` that prevents proper parsing of the schema.
 
 2.2.3 (April 13, 2020)
 ----------------------
 
 - Move nested type definitions to root of YAML files. This does not functionally change the schema but simplifies parsing of the schema and extensions by APIs.
-- Make `ImagingPlane.imaging_rate` optional to handle cases where an imaging plane is associated with multiple time series with different rates.
+- Make ``ImagingPlane.imaging_rate`` optional to handle cases where an imaging plane is associated with multiple time series with different rates.
 - Add release process documentation.
 
 2.2.2 (March 2, 2020)
 ---------------------
 
-- Fix shape and dims of `OpticalSeries.data` for color images
-- Allow more than one `OpticalChannel` object in `ImagingPlane`
-- Update hdmf-common-schema to 1.1.3. This fixes missing 'shape' and 'dims' key for types `VectorData`, `VectorIndex`, and `DynamicTableRegion`.
-- Revert changes to retinotopy.yaml in 2.1.0 which break backward compatibility and were not supported by the APIs in any case. Changes will be revisited in a future version.
+- Fix shape and dims of ``OpticalSeries.data`` for color images
+- Allow more than one ``OpticalChannel`` object in ``ImagingPlane``
+- Update hdmf-common-schema to 1.1.3. This fixes missing 'shape' and 'dims' key for types ``VectorData``, ``VectorIndex``, and ``DynamicTableRegion``.
+- Revert changes to ``nwb.retinotopy.yaml`` in 2.1.0 which break backward compatibility and were not supported by the APIs in any case. Changes will be revisited in a future version.
 
 2.2.1 (January 14, 2020)
 ------------------------
 
-- Fixed incorrect version numbers in nwb.file.yaml and hdmf-common namespace.yaml.
+- Fixed incorrect version numbers in ``nwb.file.yaml`` and ``hdmf-common-schema/common/namespace.yaml``.
 
 2.2.0 (January 6, 2020)
 -----------------------

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+2.2.5 (May 29, 2020)
+----------------------
+
+- Fix incorrect dims and shape for ``ImagingPlane.origin_coords`` and ``ImagingPlane.grid_spacing``, and fix incorrect dims for ``TwoPhotonSeries.field_of_view``.
+
 2.2.4 (April 14, 2020)
 ----------------------
 


### PR DESCRIPTION
Fix #442 and fix #443.

Also prepare for NWB 2.2.5 release today, which will include this PR and a previous PR creating CI to validate the schema.

# Prepare a release

Before merging:
- [x] Update requirements versions as needed
- [x] Update legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
  and any other locations as needed
- [x] Update `README.rst` as needed
- [x] Update the version string in `docs/source/conf.py` and `common/namespace.yaml` (remove "-alpha" suffix)
- [x] Update `docs/source/conf.py` as needed
- [x] Update release notes (set release date) in `docs/source/format_release_notes.rst` and any other docs as needed
- [x] Test docs locally (`make fulldoc`)
- [x] Push changes to this PR and make sure all PRs to be included in this release have been merged
- [x] Point the nwb-schema submodule to this branch in the PyNWB branch corresponding to this schema version and run all PyNWB tests, including validation tests
  - **see https://github.com/NeurodataWithoutBorders/pynwb/pull/1243**
- [x] Check that the readthedocs build for this PR succeeds (build latest to pull the new branch, then activate and
  build docs for new branch): https://readthedocs.org/projects/nwb-schema/builds/

After merging:
1. Create release on GitHub releases page with release notes
2. Check that the readthedocs "latest" and "stable" builds run and succeed. Deactivate build of new branch.