### PR TITLE
Use hdmf-common-schema 1.2.0

### DIFF
--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -6,6 +6,15 @@ Release Notes
 
 - Add optional ``strain`` field to ``Subject``.
 - Add to ``DecompositionSeries`` an optional ``DynamicTableRegion`` called ``source_channels``.
+- Update hdmf-common-schema to version 1.2.0. Release notes:
+  - Add software process documentation.
+  - Fix missing dtype for ``VectorIndex``.
+  - Add new ``VocabData`` data type.
+  - Move ``Data``, ``Index``, and ``Container`` to base.yaml. This change does not functionally change the schema.
+  - ``VectorIndex`` now extends ``VectorData`` instead of ``Index``. This change allows ``VectorIndex`` to index other
+    ``VectorIndex`` types.
+  - The ``Index`` data type is now unused and has been removed.
+  - Fix documentation for ragged arrays.
 
 2.2.5 (May 29, 2020)
 ----------------------


### PR DESCRIPTION
hdmf-common-schema was updated to version 1.2.0. This PR updates the hdmf-common-schema git submodule to the latest version. 

- [x] Test PyNWB API with this version
- [ ] Test MatNWB API with this version - will be tested before release