### PR TITLE
Clarify electrode impedance and filtering docs

### DIFF
--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -286,7 +286,7 @@ groups:
         - name: imp
           neurodata_type_inc: VectorData
           dtype: float32
-          doc: Impedance of the channel.
+          doc: Impedance of the channel, in ohms.
         - name: location
           neurodata_type_inc: VectorData
           dtype: text

--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -296,7 +296,7 @@ groups:
         - name: filtering
           neurodata_type_inc: VectorData
           dtype: float32
-          doc: Description of hardware filtering.
+          doc: Description of hardware filtering, including the filter name and frequency cutoffs.
         - name: group
           neurodata_type_inc: VectorData
           dtype:

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -7,7 +7,7 @@ Release Notes
 - Add optional ``strain`` field to ``Subject``.
 - Add to ``DecompositionSeries`` an optional ``DynamicTableRegion`` called ``source_channels``.
 - Add to ``ImageSeries`` an optional link to ``Device``.
-- Clarify that electrode impedance values should be stored in ohms.
+- Clarify documentation for electrode impedance and filtering.
 - Add optional "continuity" field to `TimeSeries`.
 - Update hdmf-common-schema to version 1.2.0. Release notes:
   - Add software process documentation.

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
 - Add optional ``strain`` field to ``Subject``.
 - Add to ``DecompositionSeries`` an optional ``DynamicTableRegion`` called ``source_channels``.
 - Add to ``ImageSeries`` an optional link to ``Device``.
+- Clarify that the units for electrode impedance are 'Ohms'.
 
 2.2.5 (May 29, 2020)
 ----------------------

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -7,7 +7,7 @@ Release Notes
 - Add optional ``strain`` field to ``Subject``.
 - Add to ``DecompositionSeries`` an optional ``DynamicTableRegion`` called ``source_channels``.
 - Add to ``ImageSeries`` an optional link to ``Device``.
-- Clarify that the units for electrode impedance are 'Ohms'.
+- Clarify that electrode impedance values should be stored in ohms.
 - Add optional "continuity" field to `TimeSeries`.
 - Update hdmf-common-schema to version 1.2.0. Release notes:
   - Add software process documentation.


### PR DESCRIPTION
Clarify that electrode impedance values should be stored in ohms and that the electrode filtering values should include the filter name and frequency cutoffs.

See https://github.com/NeurodataWithoutBorders/pynwb/issues/1237