### PR TITLE
Make ImageSeries/data required

### DIFF
--- a/core/nwb.image.yaml
+++ b/core/nwb.image.yaml
@@ -63,8 +63,8 @@ groups:
       - null
       - null
       - null
-    doc: Binary data representing images across frames.
-    quantity: '?'
+    doc: Binary data representing images across frames. If data are stored in an external
+      file, this should be an empty 3D array.
   - name: dimension
     dtype: int32
     dims:

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -7,6 +7,10 @@ Release Notes
 - Fix incorrect dtype for electrodes table column "filtering" (float -> text)
 - Remove "quantity: *" from the type definitions of ``OptogeneticStimulusSite`` and ``ImagingPlane``.
   This change improves clarity of the schema to follow best practices. It has no functional effect on the schema.
+- Require the "data" dataset in ``ImageSeries``. Since ``ImageSeries`` is a ``TimeSeries`` and ``TimeSeries`` requires
+  the "data" dataset, ``ImageSeries`` should also require the "data" dataset. Otherwise this creates problems for
+  inheritance and validation. If ``ImageSeries`` data are stored in an external file, then "data" should be set to
+  an empty 3D array.
 
 2.3.0 (May 12, 2021)
 ---------------------


### PR DESCRIPTION
The ``ImageSeries`` neurodata_type is a subtype of ``TimeSeries``. ``TimeSeries`` requires the dataset "data"; however, ``ImageSeries`` makes data optional because "external_file" may be provided in place of "data". This breaks the rules of inheritance -- a child must have all required fields of a parent, and this inconsistency creates challenges in NeurodataWithoutBorders/pynwb#1274

This PR makes ``ImageSeries.data`` required and updates the documentation. If "external_file" is provided, then "data" should be set to an empty 3D array.

See also discussion here: NeurodataWithoutBorders/pynwb#1220

This is related to #462 which contains broader changes.