### PR TITLE
Update TimeIntervals to use the new TimeSeriesReferenceVectorData

### DIFF
--- a/core/nwb.epoch.yaml
+++ b/core/nwb.epoch.yaml
@@ -22,20 +22,7 @@ groups:
     doc: Index for tags.
     quantity: '?'
   - name: timeseries
-    neurodata_type_inc: VectorData
-    dtype:
-    - name: idx_start
-      dtype: int32
-      doc: Start index into the TimeSeries 'data' and 'timestamp' datasets of the
-        referenced TimeSeries. The first dimension of those arrays is always time.
-    - name: count
-      dtype: int32
-      doc: Number of data samples available in this time series, during this epoch.
-    - name: timeseries
-      dtype:
-        target_type: TimeSeries
-        reftype: object
-      doc: the TimeSeries that this index applies to.
+    neurodata_type_inc: TimeSeriesReferenceVectorData
     doc: An index into a TimeSeries object.
     quantity: '?'
   - name: timeseries_index

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -2,15 +2,58 @@ Release Notes
 =============
 
 2.4.0 (Aug. 7, 2021)
-----------------
+--------------------
 
-- Fix incorrect dtype for electrodes table column "filtering" (float -> text)
-- Remove "quantity: *" from the type definitions of ``OptogeneticStimulusSite`` and ``ImagingPlane``.
-  This change improves clarity of the schema to follow best practices. It has no functional effect on the schema.
-- Require the "data" dataset in ``ImageSeries``. Since ``ImageSeries`` is a ``TimeSeries`` and ``TimeSeries`` requires
-  the "data" dataset, ``ImageSeries`` should also require the "data" dataset. Otherwise this creates problems for
-  inheritance and validation. If ``ImageSeries`` data are stored in an external file, then "data" should be set to
-  an empty 3D array.
+
+Major changes
+^^^^^^^^^^^^^
+- Added new ``TimeSeriesReferenceVectorData`` type for referencing ranges of ``TimeSeries`` from a ``VectorData`` column (#470)
+- Updated ``TimeIntervals`` to use the new  ``TimeSeriesReferenceVectorData`` type. This does not alter the overall structure
+  of ``TimeIntervals`` in a major way aside from changing the value of the ``neurodata_type`` attribute in the file
+  from ``VectorData`` to ```TimeSeriesReferenceVectorData``. This change replaces the existing ``TimeIntervals.timeseries``
+  column with a ``TimeSeriesReferenceVectorData`` type column of the same name and overall schema. This change facilitate creating
+  common functionality around ``TimeSeriesReferenceVectorData``. This change affects all existing ``TimeIntervals`` tables
+  as part of the ``intervals/`` group, i.e., ``intervals/epochs``, ``intervals/trials``, and ``intervals/invalid_times`` (#482)
+- Integrated the intracellular electrophysiology experiment metadata table structure developed as part of the
+  `ndx-icephys-meta <https://github.com/oruebel/ndx-icephys-meta>`_ extension project with NWB (#470). This includes the
+  following new types:
+
+   - ``IntracellularRecordingsTable`` is an ``AlignedDynamicTable`` for managing individual intracellular recordings and
+     to group together a stimulus and response from a single electrode recording. The table contains the following category tables:
+
+      - ``IntracellularElectrodesTable``; a ``DynamicTable`` for storing metadata about the ``IntracellularElectrode`` used
+      - ``IntracellularStimuliTable``; a ``DynamicTable`` for storing metadata about the recorded stimulus ``TimeSeries``
+        using the new ``TimeSeriesReferenceVectorData`` type to reference ``TimeSeries``
+      - ``IntracellularResponsesTable``; a ``DynamicTable`` for storing metadata about the recorded response ``TimeSeries``
+        using the new ``TimeSeriesReferenceVectorData`` type to reference ``TimeSeries``
+
+   - ``SimultaneousRecordingsTable`` is a ``DynamicTable`` for grouping different intracellular recordings from the
+     ``IntracellularRecordingsTable`` together that were recorded simultaneously from different electrodes and for
+     storing metdata about simultaneous recordings
+   - ``SequentialRecordingsTable`` is a ``DynamicTable`` for grouping different sequential recordings from the
+     ``SimultaneousRecordingsTable``  together and storing metadata about sequential recordings
+   - ``RepetitionsTable`` a ``DynamicTable`` for grouping different sequential intracellular recordings from the
+     ``SequentialRecordingsTable`` together and storing metadata about repetitions
+   - ``ExperimentalConditionsTable`` is a ``DynamicTable`` for grouping different intracellular recording repetitions
+     from the ``RepetitionsTable`` together and storing metadata about experimental conditions
+
+- Added the new intracellular electrophysiology metadata tables to ``/general/intracellular_ephys`` as part of ``NWBFile`` (#470)
+
+Deprecations
+^^^^^^^^^^^^
+- ``SweepTable`` has been deprecated in favor of the new intracellular electrophysiology  metadata tables. Use of ``SweepTable``
+  is still possible but no longer recommended. (#470)
+- ``/general/intracellular_ephys/filtering`` has been deprated in favor of ``IntracellularElectrode.filtering`` (#470)
+
+Bug Fixes
+^^^^^^^^^
+- Fix incorrect dtype for electrodes table column "filtering" (float -> text) (#478)
+- Remove ``quantity: *`` from the type definitions of ``OptogeneticStimulusSite`` and ``ImagingPlane``.
+  This change improves clarity of the schema to follow best practices. It has no functional effect on the schema. (#472)
+- Require the ``data`` dataset in ``ImageSeries``. Since ``ImageSeries`` is a ``TimeSeries`` and ``TimeSeries.data``
+  is required, ``ImageSeries.data`` should also be a required dataset. Otherwise this creates problems for
+  inheritance and validation. If ``ImageSeries`` data are stored in an external file, then ``ImageSeries.data`` should
+  be set to an empty 3D array. (#481)
 
 2.3.0 (May 12, 2021)
 ---------------------

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -43,7 +43,7 @@ Deprecations
 ^^^^^^^^^^^^
 - ``SweepTable`` has been deprecated in favor of the new intracellular electrophysiology  metadata tables. Use of ``SweepTable``
   is still possible but no longer recommended. (#470)
-- ``/general/intracellular_ephys/filtering`` has been deprated in favor of ``IntracellularElectrode.filtering`` (#470)
+- ``/general/intracellular_ephys/filtering`` has been deprecated in favor of ``IntracellularElectrode.filtering`` (#470)
 
 Bug Fixes
 ^^^^^^^^^

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -47,10 +47,10 @@ Deprecations
 
 Bug Fixes
 ^^^^^^^^^
-- Fix incorrect dtype for electrodes table column "filtering" (float -> text) (#478)
-- Remove ``quantity: *`` from the type definitions of ``OptogeneticStimulusSite`` and ``ImagingPlane``.
+- Fixed incorrect dtype for electrodes table column "filtering" (float -> text) (#478)
+- Removed ``quantity: *`` from the type definitions of ``OptogeneticStimulusSite`` and ``ImagingPlane``.
   This change improves clarity of the schema to follow best practices. It has no functional effect on the schema. (#472)
-- Require the ``data`` dataset in ``ImageSeries``. Since ``ImageSeries`` is a ``TimeSeries`` and ``TimeSeries.data``
+- Updated ``ImageSeries`` to have its ``data`` dataset be required. Since ``ImageSeries`` is a ``TimeSeries`` and ``TimeSeries.data``
   is required, ``ImageSeries.data`` should also be a required dataset. Otherwise this creates problems for
   inheritance and validation. If ``ImageSeries`` data are stored in an external file, then ``ImageSeries.data`` should
   be set to an empty 3D array. (#481)


### PR DESCRIPTION
## Motivation

#470 added the new ``TimeSeriesReferenceVectorData`` type. This PR updates ``TimeIntervals`` to use the new  ``TimeSeriesReferenceVectorData`` type. This does not alter the overall structure  of ``TimeIntervals`` in a major way aside from changing the value of the ``neurodata_type`` attribute in the file  from ``VectorData`` to ``TimeSeriesReferenceVectorData``. This change replaces the existing ``TimeIntervals.timeseries``   column with a ``TimeSeriesReferenceVectorData`` type column of the same name and overall schema. This change facilitate creating common functionality around ``TimeSeriesReferenceVectorData``. This change affects all existing ``TimeIntervals`` tables   as part of the ``intervals/`` group, i.e., ``intervals/epochs``, ``intervals/trials``, and ``intervals/invalid_times`` (#470)

## Summary of changes

- Update ``TimeIntervals`` to use the new ``TimeSeriesReferenceVectorData`` type

## PR checklist for schema changes

<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [ ] Update the version string in `docs/format/source/conf.py`, `core/nwb.namespace.yaml`, and `/core/nwb.file.yaml`
  to the next version with the suffix "-alpha"
- [X] Add a new section in the release notes for the new version with the date "Upcoming"
- [X] Add release notes for the PR to `docs/format/source/format_release_notes.rst`

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
