### PR TITLE
Revert "Update TimeIntervals to use the new TimeSeriesReferenceVectorData"

### DIFF
--- a/core/nwb.epoch.yaml
+++ b/core/nwb.epoch.yaml
@@ -22,7 +22,20 @@ groups:
     doc: Index for tags.
     quantity: '?'
   - name: timeseries
-    neurodata_type_inc: TimeSeriesReferenceVectorData
+    neurodata_type_inc: VectorData
+    dtype:
+    - name: idx_start
+      dtype: int32
+      doc: Start index into the TimeSeries 'data' and 'timestamp' datasets of the
+        referenced TimeSeries. The first dimension of those arrays is always time.
+    - name: count
+      dtype: int32
+      doc: Number of data samples available in this time series, during this epoch.
+    - name: timeseries
+      dtype:
+        target_type: TimeSeries
+        reftype: object
+      doc: the TimeSeries that this index applies to.
     doc: An index into a TimeSeries object.
     quantity: '?'
   - name: timeseries_index

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -1,19 +1,12 @@
 Release Notes
 =============
 
-2.4.0 (Aug. 7, 2021)
+2.4.0 (Aug. 11, 2021)
 --------------------
-
 
 Major changes
 ^^^^^^^^^^^^^
 - Added new ``TimeSeriesReferenceVectorData`` type for referencing ranges of ``TimeSeries`` from a ``VectorData`` column (#470)
-- Updated ``TimeIntervals`` to use the new  ``TimeSeriesReferenceVectorData`` type. This does not alter the overall structure
-  of ``TimeIntervals`` in a major way aside from changing the value of the ``neurodata_type`` attribute in the file
-  from ``VectorData`` to ```TimeSeriesReferenceVectorData``. This change replaces the existing ``TimeIntervals.timeseries``
-  column with a ``TimeSeriesReferenceVectorData`` type column of the same name and overall schema. This change facilitate creating
-  common functionality around ``TimeSeriesReferenceVectorData``. This change affects all existing ``TimeIntervals`` tables
-  as part of the ``intervals/`` group, i.e., ``intervals/epochs``, ``intervals/trials``, and ``intervals/invalid_times`` (#482)
 - Integrated the intracellular electrophysiology experiment metadata table structure developed as part of the
   `ndx-icephys-meta <https://github.com/oruebel/ndx-icephys-meta>`_ extension project with NWB (#470). This includes the
   following new types:


### PR DESCRIPTION
This reverts commit 0da613b1211cde6e916a33b03171cd1fbf26c656 and updates the release notes accordingly.

## PR checklist for schema changes

<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [ ] Update the version string in `docs/format/source/conf.py`, `core/nwb.namespace.yaml`, and `/core/nwb.file.yaml`
  to the next version with the suffix "-alpha"
- [ ] Add a new section in the release notes for the new version with the date "Upcoming"
- [ ] Add release notes for the PR to `docs/format/source/format_release_notes.rst`

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
