### PR TITLE
Add waveform conversion factor and offset to schema

### DIFF
--- a/core/nwb.misc.yaml
+++ b/core/nwb.misc.yaml
@@ -254,6 +254,14 @@ groups:
       value: volts
       doc: Unit of measurement. This value is fixed to 'volts'.
       required: false
+    - name: conversion_factor
+      dtype: float32
+      doc: Scaling factor applied to waveform data to convert it to specified unit.
+      required: false
+    - name: offset
+      dtype: float32
+      doc: Offset applied to scaled waveform data to correct any shifts.
+      required: false
   - name: waveform_sd
     neurodata_type_inc: VectorData
     dtype: float32
@@ -280,6 +288,14 @@ groups:
       dtype: text
       value: volts
       doc: Unit of measurement. This value is fixed to 'volts'.
+      required: false
+    - name: conversion_factor
+      dtype: float32
+      doc: Scaling factor applied to waveform data to convert it to specified unit.
+      required: false
+    - name: offset
+      dtype: float32
+      doc: Offset applied to scaled waveform data to correct any shifts.
       required: false
   - name: waveforms
     neurodata_type_inc: VectorData
@@ -317,6 +333,14 @@ groups:
         dtype: text
         value: volts
         doc: Unit of measurement. This value is fixed to 'volts'.
+        required: false
+      - name: conversion_factor
+        dtype: float32
+        doc: Scaling factor applied to waveform data to convert it to specified unit.
+        required: false
+      - name: offset
+        dtype: float32
+        doc: Offset applied to scaled waveform data to correct any shifts.
         required: false
   - name: waveforms_index
     neurodata_type_inc: VectorIndex


### PR DESCRIPTION
## Summary of changes
Proposing the addition of conversion factors and offsets to waveform columns of a Units table.

For large amounts of recording data, even adding waveform snippets to the columns of a Units table can be a significant task. One step towards reducing unnecessary data inflation is to add attributes for scaling factors similar to the behavior of other TimeSeries-like objects that allow the data to be stored in some minimal base type, while the conversion factor then scales it into the specified scientific units.

I've added these attributes and attempted to propagate them through the IO, mirroring the patterns established by the waveform_rate attribute.

Sister PR: https://github.com/NeurodataWithoutBorders/pynwb/pull/1422

## PR checklist for schema changes
To-Do:
 
<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [ ] Update the version string in `docs/format/source/conf.py`, `core/nwb.namespace.yaml`, and `/core/nwb.file.yaml`
  to the next version with the suffix "-alpha"
- [ ] Add a new section in the release notes for the new version with the date "Upcoming"
- [ ] Add release notes for the PR to `docs/format/source/format_release_notes.rst`

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
