### PR TITLE
Added optionality for x,y,z, filtering and impedance

### DIFF
--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -275,18 +275,22 @@ groups:
           neurodata_type_inc: VectorData
           dtype: float32
           doc: x coordinate of the channel location in the brain (+x is posterior).
+          quantity: '?'
         - name: y
           neurodata_type_inc: VectorData
           dtype: float32
           doc: y coordinate of the channel location in the brain (+y is inferior).
+          quantity: '?'
         - name: z
           neurodata_type_inc: VectorData
           dtype: float32
           doc: z coordinate of the channel location in the brain (+z is right).
+          quantity: '?'
         - name: imp
           neurodata_type_inc: VectorData
           dtype: float32
           doc: Impedance of the channel, in ohms.
+          quantity: '?'
         - name: location
           neurodata_type_inc: VectorData
           dtype: text
@@ -297,6 +301,7 @@ groups:
           neurodata_type_inc: VectorData
           dtype: text
           doc: Description of hardware filtering, including the filter name and frequency cutoffs.
+          quantity: '?'
         - name: group
           neurodata_type_inc: VectorData
           dtype:

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -8,7 +8,7 @@ Release Notes
 
 Minor changes
 ^^^^^^^^^^^^^
-- The elements `x`, `y`, `z`, `imp` and `filtering` are no longer required. 
+- The elements `x`, `y`, `z`, `imp` and `filtering` are now optional instead of required.
 - Added an ``offset`` attribute to all ``TimeSeries`` objects to allow enhanced translation to scientific units.
 
 

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
 
 Minor changes
 ^^^^^^^^^^^^^
+- The elements `x`, `y`, `z`, `imp` and `filtering` are no longer required. 
 - Added an ``offset`` attribute to all ``TimeSeries`` objects to allow enhanced translation to scientific units.
 
 


### PR DESCRIPTION
## Summary of changes

This is the first draft of the changes that should fix #505. This is my first PR here so I will welcome any help with it. I am not sure if anything else should be modified. A brief exploration in the repository gave me the idea that everything is propagated automatically from there.

Also, maybe we could modify the doc for `reference` as it seems quite unspecific as we have discussed before:
https://github.com/NeurodataWithoutBorders/nwb-schema/blob/c90e272c132b6f538d08a01b5e893247ded7d7b8/core/nwb.file.yaml#L325-L329

Previous discussion:
https://nwb-users.slack.com/archives/C5XKC14L9/p1646424876546959

EDIT:
It seems that the `reference` issue is already covered in #498.

## PR checklist for schema changes

<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
