### PR TITLE
Remove reference to NWB:N

### DIFF
--- a/docs/Readme.md
+++ b/docs/Readme.md
@@ -1,11 +1,15 @@
 **Overview**
 
-The documentation for NWB:N consists of a series of documents describing the various components of NWB:N:
+The documentation for NWB consists of a series of documents describing the various components of NWB:
 
 * ``docs/language`` with the documentation for the NWB:N specification language
 * ``docs/format`` with the documentation of the NWB:N data format
 * ``docs/storage`` with the documentation of the NWB:N storage component
 * The documentation of the PyNWB API is managed in the PyNWB git repo
+
+See also:
+* [Documentation](https://github.com/NeurodataWithoutBorders/nwb-schema-language) for the
+  [NWB Schema Language](https://schema-language.readthedocs.io/en/latest/)
 
 **Building Documentation**
 


### PR DESCRIPTION
## Summary of changes

- Minor change to remove a reference to NWB:N.
- I mostly want to test the readthedocs autobuild on PRs

## PR checklist for schema changes

<!-- If the current schema version already ends in "-alpha", then delete the first two items: -->
- [ ] Update the version string in `docs/format/source/conf.py`, `core/nwb.namespace.yaml`, and `/core/nwb.file.yaml`
  to the next version with the suffix "-alpha"
- [ ] Add a new section in the release notes for the new version with the date "Upcoming"
- [ ] Add release notes for the PR to `docs/format/source/format_release_notes.rst`

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
