### PR TITLE
Minor: Unmodify manifold

### DIFF
--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -217,7 +217,7 @@ groups:
       default_value: 1.0
       doc: Scalar to multiply each element in data to convert it to the specified 'unit'.
         If the data are stored in acquisition system units or other units
-        that require a conversion to be interpretable, multiply the data by 'conversion' and add 'offset'
+        that require a conversion to be interpretable, multiply the data by 'conversion'
         to convert the data to the specified 'unit'. e.g. if the data acquisition system
         stores values in this object as pixels from x = -500 to 499, y = -500 to 499
         that correspond to a 2 m x 2 m range, then the 'conversion' multiplier to get


### PR DESCRIPTION
## Summary of changes

- #494 had modified the docstring of `ImagingPlane.manifold.conversion` in `nwb.ophys.yaml` to reference an `offset` attribute. However, 1) no `offset` attribute was added and 2) `ImagingPlane.manifold` is deprecated. So this change should be reverted.
cc @CodyCBakerPhD 