### PR TITLE
Make nested elements in spec tables in docs more obvious

### DIFF
--- a/docs/format/source/conf_doc_autogen.py
+++ b/docs/format/source/conf_doc_autogen.py
@@ -70,7 +70,7 @@ spec_appreviate_main_object_doc_in_tables = True
 spec_show_title_for_tables = True
 
 # Char to be used as prefix to indicate the depth of an object in the specification hierarchy
-spec_table_depth_char = '.' # '→' '.'
+spec_table_depth_char = '---' # '→' '.'
 
 # Add a LaTeX clearpage after each main section describing a neurodata_type. This helps in LaTeX to keep the ordering
 # of figures, tables, and code blocks consistent in particular when the hierarchy_plots are included
@@ -90,4 +90,3 @@ spec_default_type_map = pynwb.get_type_map()
 spec_group_spec_cls = pynwb.spec.NWBGroupSpec
 spec_dataset_spec_cls = pynwb.spec.NWBDatasetSpec
 spec_namespace_spec_cls = pynwb.spec.NWBNamespace
-

--- a/docs/format/source/format_description.rst
+++ b/docs/format/source/format_description.rst
@@ -238,18 +238,18 @@ In the tables we use the following notation in the **Id** column to uniquely ide
 * ```name``` describes the unique name of an object
 * ```<neurodata_type>``` describes the ```neurodata_type``` of the object in case that the object does not have a unique name
 * ```—``` prefixes are used to indicate the depth of the object in the hierarchy to allow identification of the parent
-  of the object. E.g., an object with a ```——``` prefix will belong to the previous object with a `—` prefix.
+  of the object. E.g., an object with a ```——``` prefix will belong to the previous object with a ```—``` prefix.
 
 Here a quick example:
 
-.. tabularcolumns:: |p{4cm}|p{1cm}|p{10cm}|
+.. tabularcolumns:: |p{5cm}|p{1cm}|p{9cm}|
 .. table:: Example illustrating the description of the contents of ```neurodata_types```.
     :class: longtable
 
     +---------------------------+-------------+---------------------------------------------------------------------------------------------------------+
     | Id                        | Type        | Description                                                                                             |
     +===========================+=============+=========================================================================================================+
-    | <MyTimeSeries>            | group       | Top level group for the neurodata_type. The group the neurodata_type *MyTimeSerie*  but no fixed name   |
+    | <MyTimeSeries>            | group       | Top level group for the neurodata_type. The group the neurodata_type *MyTimeSeries* but no fixed name   |
     +---------------------------+-------------+---------------------------------------------------------------------------------------------------------+
     | —myattr                   | attribute   | Attribute with the fixed name myattr defined on <MyTimeSeries>                                          |
     +---------------------------+-------------+---------------------------------------------------------------------------------------------------------+
@@ -259,7 +259,7 @@ Here a quick example:
     +---------------------------+-------------+---------------------------------------------------------------------------------------------------------+
     | —myotherdata              | dataset     | Optional dataset with a unique name contained in <MyTimeSeries>                                         |
     +---------------------------+-------------+---------------------------------------------------------------------------------------------------------+
-    | —<ElectrialSeries>        | group       | Optional set of groups with the neurodata_type ElectricalSeries that are contained in <MyTimeSeries>    |
+    | —<ElectricalSeries>       | group       | Optional set of groups with the neurodata_type ElectricalSeries that are contained in <MyTimeSeries>    |
     +---------------------------+-------------+---------------------------------------------------------------------------------------------------------+
 
 

--- a/docs/format/source/format_description.rst
+++ b/docs/format/source/format_description.rst
@@ -237,7 +237,8 @@ In the tables we use the following notation in the **Id** column to uniquely ide
 
 * ```name``` describes the unique name of an object
 * ```<neurodata_type>``` describes the ```neurodata_type``` of the object in case that the object does not have a unique name
-* ```...``` prefixes are used to indicate the depth of the object in the hierarchy to allow identification of the parent of the object. E.g., an object with a ```..``` prefix will belong to the previous object with a `.` prefix.
+* ```—``` prefixes are used to indicate the depth of the object in the hierarchy to allow identification of the parent
+  of the object. E.g., an object with a ```——``` prefix will belong to the previous object with a `—` prefix.
 
 Here a quick example:
 
@@ -250,15 +251,15 @@ Here a quick example:
     +===========================+=============+=========================================================================================================+
     | <MyTimeSeries>            | group       | Top level group for the neurodata_type. The group the neurodata_type *MyTimeSerie*  but no fixed name   |
     +---------------------------+-------------+---------------------------------------------------------------------------------------------------------+
-    | .myattr                   | attribute   | Attribute with the fixed name myattr defined on <MyTimeSeries>                                          |
+    | —myattr                   | attribute   | Attribute with the fixed name myattr defined on <MyTimeSeries>                                          |
     +---------------------------+-------------+---------------------------------------------------------------------------------------------------------+
-    | .mydata                   | dataset     | Required dataset with a unique name contained in <MyTimeSeries>                                         |
+    | —mydata                   | dataset     | Required dataset with a unique name contained in <MyTimeSeries>                                         |
     +---------------------------+-------------+---------------------------------------------------------------------------------------------------------+
-    | ..unit                    | attribute   | Attribute unit defined on the dataset .mydata                                                           |
+    | ——unit                    | attribute   | Attribute unit defined on the dataset .mydata                                                           |
     +---------------------------+-------------+---------------------------------------------------------------------------------------------------------+
-    | .myotherdata              | dataset     | Optional dataset with a unique name contained in <MyTimeSeries>                                         |
+    | —myotherdata              | dataset     | Optional dataset with a unique name contained in <MyTimeSeries>                                         |
     +---------------------------+-------------+---------------------------------------------------------------------------------------------------------+
-    | .<ElectrialSeries>        | group       | Optional set of groups with the neurodata_type ElectricalSeries that are contained in <MyTimeSeries>    |
+    | —<ElectrialSeries>        | group       | Optional set of groups with the neurodata_type ElectricalSeries that are contained in <MyTimeSeries>    |
     +---------------------------+-------------+---------------------------------------------------------------------------------------------------------+
 
 
@@ -314,21 +315,21 @@ sufficient for other uses.
 
 **Extra fields**
 
-All parts of an NWB file should be governed by either the core schema or 
-defined in a neurodata extension (NDX). *Extra fields* are any datasets, 
-attributes, groups, links etc. that are included in a file but which are 
-not described by the NWB schema or a neurodata extension (NDX). Extra fields 
+All parts of an NWB file should be governed by either the core schema or
+defined in a neurodata extension (NDX). *Extra fields* are any datasets,
+attributes, groups, links etc. that are included in a file but which are
+not described by the NWB schema or a neurodata extension (NDX). Extra fields
 are not considered  part of the NWB file and as such, any NWB API may ignore
-extra fields. For API's this specifically means: 
+extra fields. For API's this specifically means:
 
 * an NWB file that includes extra fields should be readable by the API
   as long as the file is otherwise valid,
 * an API is permitted to ignore extra fields on read,
 * an API is permitted to ignore (including remove) extra fields on write.
 
-In practice, the use of extra fields is highly discouraged and instead neurodata 
-extensions (NDX) should be used to extend NWB to include additional fields 
-if necessary. 
+In practice, the use of extra fields is highly discouraged and instead neurodata
+extensions (NDX) should be used to extend NWB to include additional fields
+if necessary.
 
 **Why do timestamps\_link and data\_link record linking between
 datasets, but links between epochs and timeseries are not recorded?**


### PR DESCRIPTION
## Summary of changes

- Quick resolution for #514 until we have a better solution in hdmf-docutils. See https://github.com/hdmf-dev/hdmf-docutils/issues/75

## Checklist

For all schema changes:
- [ ] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.

If this is the first schema change after a schema release (i.e., the version string in `core/nwb.namespace.yaml` does not
end in "-alpha"), then:
- [ ] Update the version string in `core/nwb.namespace.yaml` and `core/nwb.file.yaml` to the next major/minor/patch
  version with the suffix "-alpha". For example, if the current version is 2.4.0 and this is a minor change, then the
  new version string should be "2.5.0-alpha".
- [ ] Update the value of the `version` variable in `docs/format/source/conf.py` to the next version **without** the
  suffix "-alpha", e.g., "2.5.0".
- [ ] Update the value of the `release` variable in `docs/format/source/conf.py` to the next version **with** the suffix
  "-alpha", e.g., "2.5.0-alpha".
- [ ] Add a new section in the release notes `docs/format/source/format_release_notes.rst` for the new version
  with the date "Upcoming" in parentheses.

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
