### PR TITLE
Revise Images.order_of_images to not have neurodata_type_inc

### DIFF
--- a/core/nwb.base.yaml
+++ b/core/nwb.base.yaml
@@ -234,7 +234,7 @@ groups:
 - neurodata_type_def: Images
   neurodata_type_inc: NWBDataInterface
   default_name: Images
-  doc: An collection of images with an optional way to specify the order of the images
+  doc: A collection of images with an optional way to specify the order of the images
     using the "order_of_images" dataset. An order must be specified if the images are
     referenced by index, e.g., from an IndexSeries.
   attributes:
@@ -246,7 +246,6 @@ groups:
     doc: Images stored in this collection.
     quantity: '+'
   - name: order_of_images
-    neurodata_type_inc: VectorData
     dims:
     - num_images
     shape:

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -16,7 +16,7 @@ Minor changes
 - Allowed ``NWBFile/stimulus/templates`` to contain ``Images`` objects. (#459)
 - Added new optional "order_of_images" dataset to ``Images`` that contains an ordered list of object references to
   ``Image`` objects stored in the same ``Images`` object. This dataset must be used if the images are referred to
-  by index, e.g., from an ``IndexSeries`` object. (#459)
+  by index, e.g., from an ``IndexSeries`` object. (#459, #518)
 - Overhauled ``IndexSeries`` type (#459):
   - Fixed dtype of ``data`` dataset of ``IndexSeries`` (int32 -> uint32).
   - Updated ``unit`` attribute of ``data`` to have fixed value "N/A".


### PR DESCRIPTION
## Summary of changes

- The modified `Images` neurodata type from #459 added a new dataset `order_of_images` that has neurodata type `VectorData`. This is not necessary and creates complications when using the object. The `VectorData` object used here must have name `"order_of_images"` (problematic in PyNWB where it is possible to create a `VectorData` with another name) and the `VectorData` must have a description. It is not necessary for this dataset to extend `VectorData` so I remove it here.

## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
