### PR TITLE
Create and use ImageReferences dataset data type

### DIFF
--- a/core/nwb.base.yaml
+++ b/core/nwb.base.yaml
@@ -57,6 +57,17 @@ datasets:
     doc: Description of the image.
     required: false
 
+- neurodata_type_def: ImageReferences
+  neurodata_type_inc: NWBData
+  dtype:
+    target_type: Image
+    reftype: object
+  dims:
+  - num_images
+  shape:
+  - null
+  doc: Ordered dataset of references to Image objects.
+
 groups:
 - neurodata_type_def: NWBContainer
   neurodata_type_inc: Container
@@ -246,13 +257,7 @@ groups:
     doc: Images stored in this collection.
     quantity: '+'
   - name: order_of_images
-    dims:
-    - num_images
-    shape:
-    - null
-    dtype:
-      target_type: Image
-      reftype: object
+    neurodata_type_inc: ImageReferences
     doc: Ordered dataset of references to Image objects stored in the parent group.
       Each Image object in the Images group should be stored once and only once, so
       the dataset should have the same length as the number of images.

--- a/core/nwb.image.yaml
+++ b/core/nwb.image.yaml
@@ -201,6 +201,10 @@ groups:
       dtype: float32
       doc: This field is unused by IndexSeries.
       required: false
+    - name: offset
+      dtype: float32
+      doc: This field is unused by IndexSeries.
+      required: false
     - name: unit
       dtype: text
       value: N/A

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -16,7 +16,8 @@ Minor changes
 - Allowed ``NWBFile/stimulus/templates`` to contain ``Images`` objects. (#459)
 - Added new optional "order_of_images" dataset to ``Images`` that contains an ordered list of object references to
   ``Image`` objects stored in the same ``Images`` object. This dataset must be used if the images are referred to
-  by index, e.g., from an ``IndexSeries`` object. (#459, #518, #519)
+  by index, e.g., from an ``IndexSeries`` object. Created new neurodata type ImageReferences which should be used
+  for this dataset. (#459, #518, #519, #520)
 - Overhauled ``IndexSeries`` type (#459):
   - Fixed dtype of ``data`` dataset of ``IndexSeries`` (int32 -> uint32).
   - Updated ``unit`` attribute of ``data`` to have fixed value "N/A".


### PR DESCRIPTION
## Summary of changes

- HDMF does not support datasets that have a name and no data type and have dtype reference (see also https://github.com/hdmf-dev/hdmf-schema-language/issues/16 ) . It was difficult to modify HDMF to support this rare use case, so this PR modifies the recently added `order_of_images` dataset to be a new data type.

## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
