### PR TITLE
Deprecate `ImagingRetinotopy`

### DIFF
--- a/core/nwb.retinotopy.yaml
+++ b/core/nwb.retinotopy.yaml
@@ -2,9 +2,9 @@ groups:
 - neurodata_type_def: ImagingRetinotopy
   neurodata_type_inc: NWBDataInterface
   default_name: ImagingRetinotopy
-  doc: 'Intrinsic signal optical imaging or widefield imaging for measuring retinotopy.
-    Stores orthogonal maps (e.g., altitude/azimuth; radius/theta) of responses to
-    specific stimuli and a combined polarity map from which to identify visual areas.
+  doc: 'DEPRECATED. Intrinsic signal optical imaging or widefield imaging for measuring
+    retinotopy. Stores orthogonal maps (e.g., altitude/azimuth; radius/theta) of responses
+    to specific stimuli and a combined polarity map from which to identify visual areas.
     This group does not store the raw responses imaged during retinotopic mapping or the
     stimuli presented, but rather the resulting phase and power maps after applying a Fourier
     transform on the averaged responses.

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -9,6 +9,7 @@ Release Notes
 Minor changes
 ^^^^^^^^^^^^^
 - Fixed typos in docstrings. (#560)
+- Deprecated `ImagingRetinotopy` neurodata type.
 
 2.6.0 (January 17, 2023)
 -----------------------

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -9,7 +9,7 @@ Release Notes
 Minor changes
 ^^^^^^^^^^^^^
 - Fixed typos in docstrings. (#560)
-- Deprecated `ImagingRetinotopy` neurodata type.
+- Deprecated `ImagingRetinotopy` neurodata type. (#565)
 
 2.6.0 (January 17, 2023)
 -----------------------


### PR DESCRIPTION
## Summary of changes

- Fix #563.

## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
