### PR TITLE
Add dataset to store list of software that produced a file

### DIFF
--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -241,11 +241,11 @@ groups:
       - name: file_name
         dtype: text
         doc: Name of script file.
-    - name: generated_by
+    - name: was_generated_by
       dtype: text
-      doc: Software package names and versions used to generate data contained in
-       an NWB File. For each software pacakge or library, include the name of the
-       software in the first column and the version in the second column.
+      doc: Name and version of software package(s) used to generate data contained in
+       this NWB File. For each software package or library, include the name of the
+       software as the first value and the version as the second value.
       dims:
       - num_sources
       - name, version

--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -241,6 +241,18 @@ groups:
       - name: file_name
         dtype: text
         doc: Name of script file.
+    - name: generated_by
+      dtype: text
+      doc: Software package names and versions used to generate data contained in
+       an NWB File. For each software pacakge or library, include the name of the
+       software in the first column and the version in the second column.
+      dims:
+      - num_sources
+      - name, version
+      shape:
+      - null
+      - 2
+      quantity: '?'
     - name: stimulus
       dtype: text
       doc: Notes about stimuli, such as how and where they were presented.

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -12,7 +12,7 @@ Minor changes
   ``waveform_sd`` columns ragged. This allows for a different number of waveform means/SDs per unit which is useful
   when each unit is associated with a different number of electrodes and there is a waveform mean/SD for each
   electrode and unit. (#576)
-
+- Added optional ``was_generated_by`` attribute to ``NWBFile`` to store provenance information (#578)
 
 2.7.0 (February 7, 2024)
 ------------------------


### PR DESCRIPTION
## Summary of changes

Fix #319.

Here is a draft proposal for basic provenance information. Given the discussion in #319, I think the goal of the first draft was an easily shareable, approachable representation where the NWB file has an optional field with the names of the software packages and versions used to generate the data in the file. 

After following up offline with @rly , we discussed that this information should likely:
1. be a dataset instead of an attribute since attributes have size limits and these lists could be large depending on the amount of information the user wants to store.
2. be a string dataset of shape (N, 2) instead of a compound data type to allow more flexible modification in the future if we want to provide the option to save additional information. The con of this approach is that the user will not know the labels without looking at the documentation.


Some further considerations might be:
- It was mentioned that this optional field could be added to all objects (not just the nwb file object). If that is preferred, should it be an optional dataset for the `Container` data type in the `hdmf-common-schema`?
- what should the name of this field be? I used `was_generated_by` based on the PROV naming, but something like `software_versions` might be more interpretable. 


Related pynwb changes here: https://github.com/NeurodataWithoutBorders/pynwb/pull/1924

## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [x] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.

If this is the first schema change after a schema release (i.e., the version string in `core/nwb.namespace.yaml` does not
end in "-alpha"), then:
- [ ] Update the version string in `core/nwb.namespace.yaml` and `core/nwb.file.yaml` to the next major/minor/patch
  version with the suffix "-alpha". For example, if the current version is 2.4.0 and this is a minor change, then the
  new version string should be "2.5.0-alpha".
- [ ] Update the value of the `version` variable in `docs/format/source/conf.py` to the next version **without** the
  suffix "-alpha", e.g., "2.5.0".
- [ ] Update the value of the `release` variable in `docs/format/source/conf.py` to the next version **with** the suffix
  "-alpha", e.g., "2.5.0-alpha".
- [ ] Add a new section in the release notes `docs/format/source/format_release_notes.rst` for the new version
  with the date "Upcoming" in parentheses.

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
