### PR TITLE
Update NWBFile nwb_version string

### DIFF
--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -7,7 +7,7 @@ groups:
   attributes:
   - name: nwb_version
     dtype: text
-    value: "2.7.0"
+    value: "2.8.0-alpha"
     doc: File version string. Use semantic versioning, e.g. 1.2.1. This will be the
       name of the format with trailing major, minor and patch numbers.
   datasets:


### PR DESCRIPTION
## Summary of changes

- The `NWBFile.nwb_version` fixed attribute should have been updated to 2.8.0-alpha in the last PR.

## Checklist

For all schema changes:
- [ ] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [x] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.

If this is the first schema change after a schema release (i.e., the version string in `core/nwb.namespace.yaml` does not
end in "-alpha"), then:
- [x] Update the version string in `core/nwb.namespace.yaml` and `core/nwb.file.yaml` to the next major/minor/patch
  version with the suffix "-alpha". For example, if the current version is 2.4.0 and this is a minor change, then the
  new version string should be "2.5.0-alpha".
- [x] Update the value of the `version` variable in `docs/format/source/conf.py` to the next version **without** the
  suffix "-alpha", e.g., "2.5.0".
- [x] Update the value of the `release` variable in `docs/format/source/conf.py` to the next version **with** the suffix
  "-alpha", e.g., "2.5.0-alpha".
- [ ] Add a new section in the release notes `docs/format/source/format_release_notes.rst` for the new version
  with the date "Upcoming" in parentheses.

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
