### PR TITLE
Add .readthedocs.yaml for storage docs

### DIFF
--- a/docs/storage/.readthedocs.yaml
+++ b/docs/storage/.readthedocs.yaml
@@ -1,0 +1,27 @@
+# Read the Docs configuration file for https://nwb-storage.readthedocs.io/en/latest/
+ # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+ # Required
+ version: 2
+
+ build:
+   os: ubuntu-22.04
+   tools:
+     python: "3.12"
+
+ # Build documentation in the docs/ directory with Sphinx
+ sphinx:
+   configuration: docs/storage/source/conf.py
+
+ # Optionally build your docs in additional formats such as PDF and ePub
+ formats: all
+
+ # Optionally set the version of Python and requirements required to build your docs
+ python:
+   install:
+     - requirements: requirements-doc.txt
+
+ # Optionally include all submodules
+ submodules:
+   include: all
+   recursive: true


### PR DESCRIPTION
## Summary of changes

Fix #585. Fix #551.

Small fix to add `.readthedocs.yaml` for the storage docs. 

## Checklist

For all schema changes:
- [ ] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [ ] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.

If this is the first schema change after a schema release (i.e., the version string in `core/nwb.namespace.yaml` does not
end in "-alpha"), then:
- [ ] Update the version string in `core/nwb.namespace.yaml` and `core/nwb.file.yaml` to the next major/minor/patch
  version with the suffix "-alpha". For example, if the current version is 2.4.0 and this is a minor change, then the
  new version string should be "2.5.0-alpha".
- [ ] Update the value of the `version` variable in `docs/format/source/conf.py` to the next version **without** the
  suffix "-alpha", e.g., "2.5.0".
- [ ] Update the value of the `release` variable in `docs/format/source/conf.py` to the next version **with** the suffix
  "-alpha", e.g., "2.5.0-alpha".
- [ ] Add a new section in the release notes `docs/format/source/format_release_notes.rst` for the new version
  with the date "Upcoming" in parentheses.

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
