### PR TITLE
Fix storage RTD for newer sphinx

### DIFF
--- a/docs/storage/source/conf.py
+++ b/docs/storage/source/conf.py
@@ -105,7 +105,7 @@ html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 def setup(app):
-   app.add_stylesheet("theme_overrides.css")  # overrides for wide tables in RTD theme
+   app.add_css_file("theme_overrides.css")  # overrides for wide tables in RTD theme
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
Now that we have the storage readthedocs page running again, this error appeared:
```
python -m sphinx -T -b html -d _build/doctrees -D language=en . $READTHEDOCS_OUTPUT/html
Running Sphinx v7.4.7
/home/docs/checkouts/readthedocs.org/user_builds/nwb-storage/checkouts/latest/docs/storage/source/conf.py:195: SyntaxWarning: invalid escape sequence '\s'
  'preamble': '\setcounter{secnumdepth}{6}',
loading translations [en]... done
making output directory... done

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/nwb-storage/envs/latest/lib/python3.12/site-packages/sphinx/cmd/build.py", line 332, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/docs/checkouts/readthedocs.org/user_builds/nwb-storage/envs/latest/lib/python3.12/site-packages/sphinx/application.py", line 267, in __init__
    self.config.setup(self)
  File "/home/docs/checkouts/readthedocs.org/user_builds/nwb-storage/checkouts/latest/docs/storage/source/conf.py", line 108, in setup
    app.add_stylesheet("theme_overrides.css")  # overrides for wide tables in RTD theme
    ^^^^^^^^^^^^^^^^^^
AttributeError: 'Sphinx' object has no attribute 'add_stylesheet'

Exception occurred:
  File "/home/docs/checkouts/readthedocs.org/user_builds/nwb-storage/checkouts/latest/docs/storage/source/conf.py", line 108, in setup
    app.add_stylesheet("theme_overrides.css")  # overrides for wide tables in RTD theme
    ^^^^^^^^^^^^^^^^^^
AttributeError: 'Sphinx' object has no attribute 'add_stylesheet'
The full traceback has been saved in /tmp/sphinx-err-mvlolqi9.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
```

`add_stylesheet` was deprecated in a recent version of sphinx. `add_css_file` should be used instead.