### PR TITLE
Make band_mean and band_std in DecompositionSeries optional

### DIFF
--- a/core/nwb.misc.yaml
+++ b/core/nwb.misc.yaml
@@ -158,6 +158,7 @@ groups:
       shape:
       - null
       doc: The mean Gaussian filters, in Hz.
+      quantity: '?'
     - name: band_stdev
       neurodata_type_inc: VectorData
       dtype: float32
@@ -166,6 +167,7 @@ groups:
       shape:
       - null
       doc: The standard deviation of Gaussian filters, in Hz.
+      quantity: '?'
   links:
   - name: source_timeseries
     target_type: TimeSeries

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -15,8 +15,8 @@ Minor changes
   electrode and unit. (#576)
 - Added optional ``was_generated_by`` attribute to ``NWBFile`` to store provenance information (#578)
 - Deprecated ``EventWaveform`` neurodata type. (#584)
-
 - Deprecated ``ImageMaskSeries`` neurodata type. (#583)
+- Made ``band_mean`` and ``band_std`` in ``DecompositionSeries`` optional. (#593)
 
 2.7.0 (February 7, 2024)
 ------------------------


### PR DESCRIPTION
## Summary of changes

Fix https://github.com/NeurodataWithoutBorders/nwb-schema/issues/570.

## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [X] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.

If this is the first schema change after a schema release (i.e., the version string in `core/nwb.namespace.yaml` does not
end in "-alpha"), then:
- [ ] Update the version string in `core/nwb.namespace.yaml` and `core/nwb.file.yaml` to the next major/minor/patch
  version with the suffix "-alpha". For example, if the current version is 2.4.0 and this is a minor change, then the
  new version string should be "2.5.0-alpha".
- [ ] Update the value of the `version` variable in `docs/format/source/conf.py` to the next version **without** the
  suffix "-alpha", e.g., "2.5.0".
- [ ] Update the value of the `release` variable in `docs/format/source/conf.py` to the next version **with** the suffix
  "-alpha", e.g., "2.5.0-alpha".
- [ ] Add a new section in the release notes `docs/format/source/format_release_notes.rst` for the new version
  with the date "Upcoming" in parentheses.

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
