### PR TITLE
Revert addition of waveform_mean_index for now

### DIFF
--- a/core/nwb.misc.yaml
+++ b/core/nwb.misc.yaml
@@ -244,13 +244,7 @@ groups:
     - - null
       - null
       - null
-    doc: Spike waveform mean for each spike unit. The 'waveform_mean_index'
-      column indexes which waveforms in this column belong to a given unit, where each waveform
-      was recorded from a different electrode. The 'electrodes' column should be used to indicate which
-      electrodes are associated with each unit, and the order of the mean waveforms for a given unit 
-      in the 'waveform_mean' dataset should be the same as the order of the electrodes referenced in
-      the 'electrodes' column of this table. The number of samples for each waveform mean must be the
-      same.
+    doc: Spike waveform mean for each spike unit.
     quantity: '?'
     attributes:
     - name: sampling_rate
@@ -262,11 +256,6 @@ groups:
       value: volts
       doc: Unit of measurement. This value is fixed to 'volts'.
       required: false
-  - name: waveform_mean_index
-    neurodata_type_inc: VectorIndex
-    doc: Optional index into the 'waveform_mean' dataset to allow each unit to have a different number of mean
-      waveforms, one per electrode. See 'waveform_mean' for more details.
-    quantity: '?'
   - name: waveform_sd
     neurodata_type_inc: VectorData
     dtype: float32
@@ -282,13 +271,7 @@ groups:
     - - null
       - null
       - null
-    doc: Spike waveform standard deviation for each spike unit. The 'waveform_sd_index'
-      column indexes which waveforms in this column belong to a given unit, where each waveform
-      was recorded from a different electrode. The 'electrodes' column should be used to indicate which
-      electrodes are associated with each unit, and the order of the waveform standard deviations for a
-      given unit in the 'waveform_sd' dataset should be the same as the order of the electrodes referenced
-      in the 'electrodes' column of this table. The number of samples for each waveform standard deviation
-      must be the same.
+    doc: Spike waveform standard deviation for each spike unit.
     quantity: '?'
     attributes:
     - name: sampling_rate
@@ -300,11 +283,6 @@ groups:
       value: volts
       doc: Unit of measurement. This value is fixed to 'volts'.
       required: false
-  - name: waveform_sd_index
-    neurodata_type_inc: VectorIndex
-    doc: Optional index into the 'waveform_sd' dataset to allow each unit to have a different number of
-      waveform standard deviations, one per electrode. See 'waveform_sd' for more details.
-    quantity: '?'
   - name: waveforms
     neurodata_type_inc: VectorData
     dtype: numeric

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -9,10 +9,6 @@ Release Notes
 Minor changes
 ^^^^^^^^^^^^^
 - Added support to set boundary metadata for ``SpatialSeries``. (#524)
-- Added columns ``waveform_mean_index`` and ``waveform_sd_index`` to ``Units`` to make the ``waveform_mean`` and
-  ``waveform_sd`` columns ragged. This allows for a different number of waveform means/SDs per unit which is useful
-  when each unit is associated with a different number of electrodes and there is a waveform mean/SD for each
-  electrode and unit. (#576)
 - Added optional ``was_generated_by`` attribute to ``NWBFile`` to store provenance information (#578)
 - Deprecated ``EventWaveform`` neurodata type. (#584)
 - Deprecated ``ImageMaskSeries`` neurodata type. (#583)


### PR DESCRIPTION
## Summary of changes

- Based on discussion today with @oruebel and @stephprince, we decided to revert the change to make "waveform_mean" and "waveform_sd" ragged because of confusing access patterns and conflict with the current 2D/3D schema. We will discuss this with the NWB TAB. The tentative plan is to create a new column "electrodes_waveform_means" and "electrodes_waveform_sds" and slowly phase out "waveform_mean" and "waveform_sd" in favor of this more general column.

## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [x] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.
