### PR TITLE
Revert addition of "bounds" to SpatialSeries temporarily

### DIFF
--- a/core/nwb.behavior.yaml
+++ b/core/nwb.behavior.yaml
@@ -38,24 +38,6 @@ groups:
         is 'meters'. Actual stored values are not necessarily stored in these units.
         To access the data in these units, multiply 'data' by 'conversion' and add 'offset'.
       required: false
-    - name: bounds
-      dtype: numeric
-      doc: The boundary range (min, max) for each dimension of `data`. The units are the same as the units for the data.
-      shape:
-      - - 1
-        - 2
-      - - 2
-        - 2
-      - - 3
-        - 2 
-      dims:
-      - - x
-        - min,max
-      - - x,y
-        - min,max
-      - - x,y,z
-        - min,max
-      required: false
   - name: reference_frame
     dtype: text
     doc: Description defining what exactly 'straight-ahead' means.

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -8,7 +8,6 @@ Release Notes
 
 Minor changes
 ^^^^^^^^^^^^^
-- Added support to set boundary metadata for ``SpatialSeries``. (#524)
 - Added optional ``was_generated_by`` attribute to ``NWBFile`` to store provenance information (#578)
 - Deprecated ``EventWaveform`` neurodata type. (#584)
 - Deprecated ``ImageMaskSeries`` neurodata type. (#583)


### PR DESCRIPTION
## Summary of changes

- See https://github.com/NeurodataWithoutBorders/pynwb/issues/1992

## Checklist

For all schema changes:
- [ ] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [x] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.
