### PR TITLE
Make group quantities consistent across data interfaces / wrapper types

### DIFF
--- a/core/nwb.behavior.yaml
+++ b/core/nwb.behavior.yaml
@@ -61,7 +61,7 @@ groups:
   groups:
   - neurodata_type_inc: IntervalSeries
     doc: IntervalSeries object containing start and stop times of epochs.
-    quantity: '*'
+    quantity: '+'
 
 - neurodata_type_def: BehavioralEvents
   neurodata_type_inc: NWBDataInterface
@@ -71,7 +71,7 @@ groups:
   groups:
   - neurodata_type_inc: TimeSeries
     doc: TimeSeries object containing behavioral events.
-    quantity: '*'
+    quantity: '+'
 
 - neurodata_type_def: BehavioralTimeSeries
   neurodata_type_inc: NWBDataInterface
@@ -81,7 +81,7 @@ groups:
   groups:
   - neurodata_type_inc: TimeSeries
     doc: TimeSeries object containing continuous behavioral data.
-    quantity: '*'
+    quantity: '+'
 
 - neurodata_type_def: PupilTracking
   neurodata_type_inc: NWBDataInterface
@@ -99,7 +99,7 @@ groups:
   groups:
   - neurodata_type_inc: SpatialSeries
     doc: SpatialSeries object containing data measuring direction of gaze.
-    quantity: '*'
+    quantity: '+'
 
 - neurodata_type_def: CompassDirection
   neurodata_type_inc: NWBDataInterface
@@ -112,7 +112,7 @@ groups:
   groups:
   - neurodata_type_inc: SpatialSeries
     doc: SpatialSeries object containing direction of gaze travel.
-    quantity: '*'
+    quantity: '+'
 
 - neurodata_type_def: Position
   neurodata_type_inc: NWBDataInterface

--- a/core/nwb.ecephys.yaml
+++ b/core/nwb.ecephys.yaml
@@ -196,7 +196,7 @@ groups:
   groups:
   - neurodata_type_inc: SpikeEventSeries
     doc: SpikeEventSeries object(s) containing detected spike event waveforms.
-    quantity: '*'
+    quantity: '+'
 
 - neurodata_type_def: FilteredEphys
   neurodata_type_inc: NWBDataInterface

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -12,6 +12,7 @@ Major changes
 
 Minor changes
 ^^^^^^^^^^^^^
+- Made group quantities consistent ("1 or more") across data interfaces / wrapper types
 - Fixed typo and removed HTML tag from doc of behavioral neurodata types. (#600)
 
 2.8.0 (November 24, 2024)

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -12,7 +12,7 @@ Major changes
 
 Minor changes
 ^^^^^^^^^^^^^
-- Made group quantities consistent ("1 or more") across data interfaces / wrapper types
+- Made group quantities consistent ("1 or more") across data interfaces / wrapper types (#613)
 - Fixed typo and removed HTML tag from doc of behavioral neurodata types. (#600)
 
 2.8.0 (November 24, 2024)


### PR DESCRIPTION
Fix #611 

## Summary of changes
Change quantity from "*" to "+" for groups of wrapper types

## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [x] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.
