### PR TITLE
Use ExternalImage.data instead of file_path

### DIFF
--- a/core/nwb.base.yaml
+++ b/core/nwb.base.yaml
@@ -64,12 +64,10 @@ datasets:
 
 - neurodata_type_def: ExternalImage
   neurodata_type_inc: BaseImage
-  doc: A type for referencing an external image file.
-  attributes:
-  - name: file_path
-    dtype: text
-    doc: Path or URL to the external image file.
-    required: true
+  doc: A type for referencing an external image file. The single file path or URL to the external image file should
+    be stored in the dataset.
+  dtype: text
+  # shape: scalar  # this will be supported in the NWB schema language 2.0
 
 - neurodata_type_def: ImageReferences
   neurodata_type_inc: NWBData

--- a/core/nwb.base.yaml
+++ b/core/nwb.base.yaml
@@ -65,7 +65,8 @@ datasets:
 - neurodata_type_def: ExternalImage
   neurodata_type_inc: BaseImage
   doc: A type for referencing an external image file. The single file path or URL to the external image file should
-    be stored in the dataset.
+    be stored in the dataset. This type should NOT be used if the image is stored 
+     in another NWB file and that file is linked to this file.
   dtype: text
   # shape: scalar  # this will be supported in the NWB schema language 2.0
 

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -8,7 +8,7 @@ Release Notes
 
 Major changes
 ^^^^^^^^^^^^^
-- Added `BaseImage` and `ExternalImage` as new neurodata types. The first so both `Image` and `ExternalImage` can inherit from it. The second to store external images (#604)
+- Added `BaseImage` and `ExternalImage` as new neurodata types. The first so both `Image` and `ExternalImage` can inherit from it. The second to store external images (#604, #623)
 
 Minor changes
 ^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary of changes

From #604: the new `BaseImage` type is a dataset where the data has no constraints on dtype or shape but is required.  The new `ExternalImage` has an attribute for `file_path` but because it inherits from `BaseImage`, it is also a dataset and therefore has a required data value. @oruebel and I think that `ExternalImage.data` should be used to store the scalar string file path instead of the attribute.

We cannot yet specify that `ExternalImage.data` must be a scalar, so we leave the shape to be Any shape. `shape: scalar` will be supported in the new 2.0 schema language.

## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [x] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.

If this is the first schema change after a schema release (i.e., the version string in `core/nwb.namespace.yaml` does not
end in "-alpha"), then:
- [ ] Update the version string in `core/nwb.namespace.yaml` and `core/nwb.file.yaml` to the next major/minor/patch
  version with the suffix "-alpha". For example, if the current version is 2.4.0 and this is a minor change, then the
  new version string should be "2.5.0-alpha".
- [ ] Update the value of the `version` variable in `docs/format/source/conf.py` to the next version **without** the
  suffix "-alpha", e.g., "2.5.0".
- [ ] Update the value of the `release` variable in `docs/format/source/conf.py` to the next version **with** the suffix
  "-alpha", e.g., "2.5.0-alpha".
- [ ] Add a new section in the release notes `docs/format/source/format_release_notes.rst` for the new version
  with the date "Upcoming" in parentheses.

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
