### PR TITLE
Add ExternalImage.image_mode and image_format

### DIFF
--- a/core/nwb.base.yaml
+++ b/core/nwb.base.yaml
@@ -64,11 +64,21 @@ datasets:
 
 - neurodata_type_def: ExternalImage
   neurodata_type_inc: BaseImage
-  doc: A type for referencing an external image file. The single file path or URL to the external image file should
-    be stored in the dataset. This type should NOT be used if the image is stored 
-     in another NWB file and that file is linked to this file.
+  doc: A type for referencing an external image file. The single file path or URI to the
+    external image file should be stored in the dataset. This type should NOT be used if
+    the image is stored in another NWB file and that file is linked to this file.
   dtype: text
   # shape: scalar  # this will be supported in the NWB schema language 2.0
+  attributes:
+  - name: image_mode
+    dtype: text
+    doc: Image mode (color mode) of the image, e.g., "RGB", "RGBA", "grayscale", and "LA".
+    required: true
+  - name: image_format
+    dtype: text
+    doc: Common name of the image file format. Only widely readable, open file formats are allowed.
+      Allowed values are "PNG", "JPEG", "GIF", and "TIFF".
+    required: true
 
 - neurodata_type_def: ImageReferences
   neurodata_type_inc: NWBData

--- a/core/nwb.base.yaml
+++ b/core/nwb.base.yaml
@@ -77,7 +77,7 @@ datasets:
   - name: image_format
     dtype: text
     doc: Common name of the image file format. Only widely readable, open file formats are allowed.
-      Allowed values are "PNG", "JPEG", "GIF", and "TIFF".
+      Allowed values are "PNG", "JPEG", and "GIF".
     required: true
 
 - neurodata_type_def: ImageReferences

--- a/core/nwb.base.yaml
+++ b/core/nwb.base.yaml
@@ -73,7 +73,7 @@ datasets:
   - name: image_mode
     dtype: text
     doc: Image mode (color mode) of the image, e.g., "RGB", "RGBA", "grayscale", and "LA".
-    required: true
+    required: false
   - name: image_format
     dtype: text
     doc: Common name of the image file format. Only widely readable, open file formats are allowed.

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -8,7 +8,8 @@ Release Notes
 
 Major changes
 ^^^^^^^^^^^^^
-- Added `BaseImage` and `ExternalImage` as new neurodata types. The first so both `Image` and `ExternalImage` can inherit from it. The second to store external images (#604, #623)
+- Added `BaseImage` and `ExternalImage` as new neurodata types. The first so both `Image` and `ExternalImage` 
+  can inherit from it. The second to store external images (#604, #623, #627)
 
 Minor changes
 ^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary of changes

- Follow-up to #604 and $623 to account for comments in https://github.com/NeurodataWithoutBorders/nwb-schema/issues/603#issuecomment-2616464570 following TAB discussion.

I thought about restricting image modes to common ones, but different programming languages (we care primarily about Python Pillow, Matlab, and Javascript) have different support for different modes (and color spaces and bit depths) in different formats.... it gets quite complicated. We could also remove the `image_mode` attribute entirely or make it optional. It is used only as a hint to the user about what is in the data and as an additional way to validate the data.

However, I think restricting image formats to open formats that are widely supported makes sense. We do not want NWB files that link to proprietary or unreadable image file formats.

## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [x] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.
