### PR TITLE
Make SpikeEventSeries.timestamps explicitly required

### DIFF
--- a/core/nwb.ecephys.yaml
+++ b/core/nwb.ecephys.yaml
@@ -104,6 +104,7 @@ groups:
       common experiment master-clock stored in NWBFile.timestamps_reference_time.
       Timestamps are required for the events. Unlike for TimeSeries, timestamps are
       required for SpikeEventSeries and are thus re-specified here.
+    quantity: 1
     attributes:
     - name: interval
       dtype: int32

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -12,7 +12,7 @@ Major changes
   can inherit from it. The second to store external images (#604, #623, #627)
 - Changed ``NWBFile.electrodes`` from a generic ``DynamicTable`` with added columns to a new ``ElectrodesTable`` 
   neurodata type that extends ``DynamicTable`` with added columns. (#539, #624)
-- Made SpikeEventSeries.timestamps explicitly required as described in the documentation. (#629)
+- Made ``SpikeEventSeries.timestamps`` explicitly required as described in the documentation. (#629)
 - Changed ``DecompositionSeries.bands`` from a generic ``DynamicTable`` with added columns to a new ``FrequencyBandsTable`` neurodata type that extends ``DynamicTable`` with added columns. (#610)
 
 Minor changes

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -12,6 +12,7 @@ Major changes
   can inherit from it. The second to store external images (#604, #623, #627)
 - Changed ``NWBFile.electrodes`` from a generic ``DynamicTable`` with added columns to a new ``ElectrodesTable`` 
   neurodata type that extends ``DynamicTable`` with added columns. (#539, #624)
+- Made SpikeEventSeries.timestamps explicitly required as described in the documentation. 
 
 Minor changes
 ^^^^^^^^^^^^^

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -12,7 +12,7 @@ Major changes
   can inherit from it. The second to store external images (#604, #623, #627)
 - Changed ``NWBFile.electrodes`` from a generic ``DynamicTable`` with added columns to a new ``ElectrodesTable`` 
   neurodata type that extends ``DynamicTable`` with added columns. (#539, #624)
-- Made SpikeEventSeries.timestamps explicitly required as described in the documentation. 
+- Made SpikeEventSeries.timestamps explicitly required as described in the documentation. (#629)
 
 Minor changes
 ^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary of changes

- Fix #622

## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [x] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.
