### PR TITLE
Deprecate `EventDetection.times`

### DIFF
--- a/core/nwb.ecephys.yaml
+++ b/core/nwb.ecephys.yaml
@@ -179,12 +179,12 @@ groups:
     - num_events
     shape:
     - null
-    doc: Timestamps of events, in seconds.
+    doc: DEPRECATED. Timestamps of events, in seconds.
     attributes:
     - name: unit
       dtype: text
       value: seconds
-      doc: DEPRECATED. Unit of measurement for event times, which is fixed to 'seconds'.
+      doc: Unit of measurement for event times, which is fixed to 'seconds'.
     quantity: '?'
   links:
   - name: source_electricalseries

--- a/core/nwb.ecephys.yaml
+++ b/core/nwb.ecephys.yaml
@@ -184,7 +184,7 @@ groups:
     - name: unit
       dtype: text
       value: seconds
-      doc: Unit of measurement for event times, which is fixed to 'seconds'.
+      doc: DEPRECATED. Unit of measurement for event times, which is fixed to 'seconds'.
     quantity: '?'
   links:
   - name: source_electricalseries

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -29,7 +29,7 @@ Minor changes
 - Made group quantities consistent ("1 or more") across data interfaces / wrapper types (#613)
 - Fixed typo and removed HTML tag from doc of behavioral neurodata types. (#600)
 - Improved the documentation of ``IndexSeries``. (#614)
-- Made ``EventDetection.times`` optional. (#620)
+- Made ``EventDetection.times`` optional and deprecated. Use `source_idx` instead. (#620)
 
 2.8.0 (November 24, 2024)
 -------------------------


### PR DESCRIPTION
## Summary of changes

Following discussion related to https://github.com/NeurodataWithoutBorders/nwb-schema/issues/555 and https://github.com/NeurodataWithoutBorders/nwb-schema/issues/619, `EventDetection.times` stores duplicate information as the `source_idx` and there are currently no checks that the two agree with each other. Since there are minimal example usages of `EventDetection` on DANDI, it may be best to deprecate this dataset.

## Checklist

For all schema changes:
- [X] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [X] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.

If this is the first schema change after a schema release (i.e., the version string in `core/nwb.namespace.yaml` does not
end in "-alpha"), then:
- [ ] Update the version string in `core/nwb.namespace.yaml` and `core/nwb.file.yaml` to the next major/minor/patch
  version with the suffix "-alpha". For example, if the current version is 2.4.0 and this is a minor change, then the
  new version string should be "2.5.0-alpha".
- [ ] Update the value of the `version` variable in `docs/format/source/conf.py` to the next version **without** the
  suffix "-alpha", e.g., "2.5.0".
- [ ] Update the value of the `release` variable in `docs/format/source/conf.py` to the next version **with** the suffix
  "-alpha", e.g., "2.5.0-alpha".
- [ ] Add a new section in the release notes `docs/format/source/format_release_notes.rst` for the new version
  with the date "Upcoming" in parentheses.

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
