### PR TITLE
Update default type map to None for TypeMap generation

### DIFF
--- a/docs/format/source/conf_doc_autogen.py
+++ b/docs/format/source/conf_doc_autogen.py
@@ -80,10 +80,10 @@ spec_add_latex_clearpage_after_ndt_sections = True
 # or to show only the parts that are actually new to a current type while only linking to base types
 spec_resolve_type_inc = False
 
-# Default type map to be used. This is the type map where dependent namespaces are stored. In the case of
-# NWB this is spec_default_type_map = pynwb.get_type_map()
 import pynwb
-spec_default_type_map = pynwb.get_type_map()
+
+# Generate a clean TypeMap using the namespace from this repo
+spec_default_type_map = None
 
 # Default specification classes for groups datasets and namespaces. In the case of NWB these are the NWB-specfic
 # spec classes. In the general cases these are the spec classes from HDMF

--- a/docs/format/source/conf_doc_autogen.py
+++ b/docs/format/source/conf_doc_autogen.py
@@ -82,7 +82,8 @@ spec_resolve_type_inc = False
 
 import pynwb
 
-# Generate a clean TypeMap using the namespace from this repo
+# `None` forces hdmf-docutils to build a fresh NamespaceCatalog from this repo's YAML,
+# avoiding stale-version conflicts when pynwb has an older `core` namespace already loaded.
 spec_default_type_map = None
 
 # Default specification classes for groups datasets and namespaces. In the case of NWB these are the NWB-specfic

--- a/docs/format/source/conf_doc_autogen.py
+++ b/docs/format/source/conf_doc_autogen.py
@@ -81,13 +81,27 @@ spec_add_latex_clearpage_after_ndt_sections = True
 spec_resolve_type_inc = False
 
 import pynwb
-
-# `None` forces hdmf-docutils to build a fresh NamespaceCatalog from this repo's YAML,
-# avoiding stale-version conflicts when pynwb has an older `core` namespace already loaded.
-spec_default_type_map = None
+from hdmf.build import TypeMap
+from hdmf.spec import NamespaceCatalog
 
 # Default specification classes for groups datasets and namespaces. In the case of NWB these are the NWB-specfic
 # spec classes. In the general cases these are the spec classes from HDMF
 spec_group_spec_cls = pynwb.spec.NWBGroupSpec
 spec_dataset_spec_cls = pynwb.spec.NWBDatasetSpec
 spec_namespace_spec_cls = pynwb.spec.NWBNamespace
+
+# Build a TypeMap whose catalog has only `hdmf-common` pre-loaded. When hdmf-docutils
+# layers `core` on top, the `hdmf-common` dependency resolves while `core` itself is read
+# fresh from this checkout's YAML. Do not use `pynwb.get_type_map()` because it includes
+# the `core` that is bundled with pynwb, which can lag this repo's version and silently
+# shadow it.
+_hdmf_common_namespace_file = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '../../../hdmf-common-schema/common/namespace.yaml')
+)
+_namespace_catalog = NamespaceCatalog(
+    group_spec_cls=spec_group_spec_cls,
+    dataset_spec_cls=spec_dataset_spec_cls,
+    spec_namespace_cls=spec_namespace_spec_cls,
+)
+_namespace_catalog.load_namespaces(_hdmf_common_namespace_file)
+spec_default_type_map = TypeMap(_namespace_catalog)

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,4 +1,4 @@
-hdmf-docutils
+hdmf-docutils>=0.4.10
 pynwb
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
Changed the default type map to None for a clean TypeMap generation.

## Summary of changes

- Fix #601

## Checklist

For all schema changes:
- [ ] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [ ] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.

If this is the first schema change after a schema release (i.e., the version string in `core/nwb.namespace.yaml` does not
end in "-alpha"), then:
- [ ] Update the version string in `core/nwb.namespace.yaml` and `core/nwb.file.yaml` to the next major/minor/patch
  version with the suffix "-alpha". For example, if the current version is 2.4.0 and this is a minor change, then the
  new version string should be "2.5.0-alpha".
- [ ] Update the value of the `version` variable in `docs/format/source/conf.py` to the next version **without** the
  suffix "-alpha", e.g., "2.5.0".
- [ ] Update the value of the `release` variable in `docs/format/source/conf.py` to the next version **with** the suffix
  "-alpha", e.g., "2.5.0-alpha".
- [ ] Add a new section in the release notes `docs/format/source/format_release_notes.rst` for the new version
  with the date "Upcoming" in parentheses.

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
