### PR TITLE
Improving documentation for resolution attribute in the `Units` table

### DIFF
--- a/core/nwb.misc.yaml
+++ b/core/nwb.misc.yaml
@@ -201,9 +201,9 @@ groups:
       dtype: float64
       doc: The temporal resolution of the spike times, in seconds. This is typically the sampling period (1/sampling_rate)
         of the acquisition data from which spikes were extracted. If the acquisition data was downsampled before
-        spike sorting, the resolution should be the downsampled frequency (lower sampling frequency, larger resolution value). If interpolation
+        spike sorting, the resolution should be based on the downsampled sampling rate (lower sampling rate, larger resolution value). If interpolation
         was applied during spike sorting, then spike times may fall between samples of the acquisition data, so the
-        resolution should be the interpolation step size (higher sampling frequency, smaller resolution value).
+        resolution should be the interpolation step size (higher sampling rate, smaller resolution value).
       required: false
   - name: obs_intervals_index
     neurodata_type_inc: VectorIndex

--- a/core/nwb.misc.yaml
+++ b/core/nwb.misc.yaml
@@ -200,9 +200,10 @@ groups:
     - name: resolution
       dtype: float64
       doc: The temporal resolution of the spike times, in seconds. This is typically the sampling period (1/sampling_rate)
-        of the acquisition data from which spikes were extracted. Notes - (1) If the acquisition data was downsampled before
-        spike sorting, the resolution will be larger (coarser) than the original acquisition sampling period. (2) If
-        interpolation was applied during spike sorting, spike times may fall between samples of the acquisition data.
+        of the acquisition data from which spikes were extracted. If the acquisition data was downsampled before
+        spike sorting, the resolution should be the downsampled frequency (lower sampling frequency, larger resolution value). If interpolation
+        was applied during spike sorting, then spike times may fall between samples of the acquisition data, so the
+        resolution should be the interpolation step size (higher sampling frequency, smaller resolution value).
       required: false
   - name: obs_intervals_index
     neurodata_type_inc: VectorIndex

--- a/core/nwb.misc.yaml
+++ b/core/nwb.misc.yaml
@@ -199,10 +199,10 @@ groups:
     attributes:
     - name: resolution
       dtype: float64
-      doc: The smallest possible difference between two spike times. Usually 1 divided by the acquisition sampling rate
-        from which spike times were extracted, but could be larger if the acquisition time series was downsampled or
-        smaller if the acquisition time series was smoothed/interpolated and it is possible for the spike time to be
-        between samples.
+      doc: The temporal resolution of the spike times, in seconds. This is typically the sampling period (1/sampling_rate)
+        of the acquisition data from which spikes were extracted. Notes - (1) If the acquisition data was downsampled before
+        spike sorting, the resolution will be larger (coarser) than the original acquisition sampling period. (2) If
+        interpolation was applied during spike sorting, spike times may fall between samples of the acquisition data.
       required: false
   - name: obs_intervals_index
     neurodata_type_inc: VectorIndex

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -16,8 +16,10 @@ Minor changes
   that are typically used together for analysis, such as spike sorting. (#659)
 - Specified that units for ``ElectrodesTable`` coordinate fields (``x``, ``y``, ``z``, ``rel_x``, ``rel_y``, ``rel_z``)
   should be in microns. (#658)
-- Expanded documentation for the ``Subject`` 'age' dataset, including details on ISO 8601 Duration format and 
+- Expanded documentation for the ``Subject`` 'age' dataset, including details on ISO 8601 Duration format and
   age range representation.
+- Improved documentation of ``Units.spike_times.resolution`` to clarify that it represents the temporal resolution
+  (sampling period) of the spike times. (#666)
 
 2.9.0 (June 26, 2025)
 ---------------------


### PR DESCRIPTION
The [`resolution`](https://github.com/NeurodataWithoutBorders/nwb-schema/blob/362c0958528868ac323b1d986ecba5050d0cbd36/core/nwb.misc.yaml#L200-L206) attribute on the `spike_times` dataset was added in [PR #328](https://github.com/NeurodataWithoutBorders/nwb-schema/pull/328) to address [issue #327](https://github.com/NeurodataWithoutBorders/nwb-schema/issues/327). The intent was to store the sampling period of the source acquisition data from which spike times were extracted, allowing users to understand the temporal precision of the spike times.

The current documentation describes it as "the smallest possible difference between two spike times" with a note that it is "usually 1 divided by the acquisition sampling rate". This phrasing is indirect and potentially confusing. Since the intent is to store the inverse of the acquisition sampling rate (i.e., the sampling period), the documentation should state this directly rather than describing it in terms of spike time differences. 

After a discussion with @alejoe91 we thought that this could be improved and here is the result. 

## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [x] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.

If this is the first schema change after a schema release (i.e., the version string in `core/nwb.namespace.yaml` does not
end in "-alpha"), then:
- [x] Update the version string in `core/nwb.namespace.yaml` and `core/nwb.file.yaml` to the next major/minor/patch
  version with the suffix "-alpha". For example, if the current version is 2.4.0 and this is a minor change, then the
  new version string should be "2.5.0-alpha".
- [x] Update the value of the `version` variable in `docs/format/source/conf.py` to the next version **without** the
  suffix "-alpha", e.g., "2.5.0".
- [x] Update the value of the `release` variable in `docs/format/source/conf.py` to the next version **with** the suffix
  "-alpha", e.g., "2.5.0-alpha".
- [x] Add a new section in the release notes `docs/format/source/format_release_notes.rst` for the new version
  with the date "Upcoming" in parentheses.

<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
