### PR TITLE
Enhance age dataset documentation

### DIFF
--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -415,7 +415,13 @@ groups:
   datasets:
   - name: age
     dtype: text
-    doc: Age of subject. Can be supplied instead of 'date_of_birth'.
+    doc: "Age of subject. Can be supplied instead of 'date_of_birth'.
+      The ISO 8601 Duration format is recommended, e.g., 'P90D' for 90 days old.
+      A timedelta will automatically be converted to The ISO 8601 Duration format.
+      If the precise age is unknown, an age range can be given by '[lower bound]/[upper bound]' e.g.
+      'P10D/P20D' would mean that the age is in between 10 and 20 days. If only the lower bound is known,
+      then including only the slash after that lower bound can be used to indicate a missing bound.
+      For instance, 'P90Y/' would indicate that the age is 90 years or older."
     quantity: '?'
     attributes:
       - name: reference

--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -417,7 +417,6 @@ groups:
     dtype: text
     doc: "Age of subject. Can be supplied instead of 'date_of_birth'.
       The ISO 8601 Duration format is recommended, e.g., 'P90D' for 90 days old.
-      A timedelta will automatically be converted to The ISO 8601 Duration format.
       If the precise age is unknown, an age range can be given by '[lower bound]/[upper bound]' e.g.
       'P10D/P20D' would mean that the age is in between 10 and 20 days. If only the lower bound is known,
       then including only the slash after that lower bound can be used to indicate a missing bound.

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -12,6 +12,8 @@ Minor changes
   that are typically used together for analysis, such as spike sorting. (#659)
 - Specified that units for ``ElectrodesTable`` coordinate fields (``x``, ``y``, ``z``, ``rel_x``, ``rel_y``, ``rel_z``)
   should be in microns. (#658)
+- Expanded documentation for the ``Subject`` 'age' dataset, including details on ISO 8601 Duration format and 
+  age range representation.
 
 
 2.9.0 (June 26, 2025)


### PR DESCRIPTION
Expanded documentation for the 'age' dataset, including details on ISO 8601 Duration format and age range representation. 

Copied from NWB best practices nwbinspector.readthedocs.io/en/dev/best_practices/nwbfile_metadata.html#subject

In concert with https://github.com/NeurodataWithoutBorders/pynwb/pull/2161


## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [x] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.
