### PR TITLE
Clarify Units.spike_times and Units.obs_intervals documentation

### DIFF
--- a/core/nwb.misc.yaml
+++ b/core/nwb.misc.yaml
@@ -194,7 +194,9 @@ groups:
   - name: spike_times
     neurodata_type_inc: VectorData
     dtype: float64
-    doc: Spike times for each unit in seconds.
+    doc: Spike times for each unit, in seconds, relative to the session reference
+      time (i.e. session_start_time or, if defined, timestamps_reference_time).
+      Times should be stored in ascending order.
     quantity: '?'
     attributes:
     - name: resolution
@@ -217,7 +219,9 @@ groups:
     shape:
     - null
     - 2
-    doc: Observation intervals for each unit.
+    doc: Observation intervals for each unit, in seconds, relative to the session
+      reference time (i.e. session_start_time or, if defined, timestamps_reference_time).
+      Intervals should be in ascending order and non-overlapping.
     quantity: '?'
   - name: electrodes_index
     neurodata_type_inc: VectorIndex

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -16,8 +16,10 @@ Minor changes
   that are typically used together for analysis, such as spike sorting. (#659)
 - Specified that units for ``ElectrodesTable`` coordinate fields (``x``, ``y``, ``z``, ``rel_x``, ``rel_y``, ``rel_z``)
   should be in microns. (#658)
-- Expanded documentation for the ``Subject`` 'age' dataset, including details on ISO 8601 Duration format and 
+- Expanded documentation for the ``Subject`` 'age' dataset, including details on ISO 8601 Duration format and
   age range representation.
+- Clarified ``Units.spike_times`` and ``Units.obs_intervals`` documentation to specify that times are relative
+  to the session reference time and that values should be stored in ascending order. (#676)
 
 2.9.0 (June 26, 2025)
 ---------------------


### PR DESCRIPTION
## Summary of changes

The `spike_times` and `obs_intervals` doc strings in the `Units` type now specify that times are relative to the session reference time (i.e. `session_start_time` or, if defined, `timestamps_reference_time`). The `spike_times` doc states that values should be stored in ascending order, and `obs_intervals` adds that intervals should be non-overlapping. These are documentation-only changes that codify existing assumptions without breaking any files.

## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [x] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.

