### PR TITLE
Add optional `num_samples` dataset to `ImageSeries` for external file timing

### DIFF
--- a/core/nwb.image.yaml
+++ b/core/nwb.image.yaml
@@ -102,6 +102,14 @@ groups:
         attribute will have values [0, 5, 15]. If there is a single external file that
         holds all of the frames of the ImageSeries (and so there is a single element in
         the 'external_file' dataset), then this attribute should have value [0].
+  - name: num_samples
+    dtype: uint32
+    doc: Total number of frames across all external files. This is required when
+      format='external' and timing is described using starting_time and rate, since
+      data is empty and its first dimension cannot be used to determine the number
+      of frames. When timestamps is provided, len(timestamps) already serves this
+      purpose.
+    quantity: '?'
   - name: format
     dtype: text
     default_value: raw

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -12,11 +12,15 @@ Major changes
 
 Minor changes
 ^^^^^^^^^^^^^
+- Added optional ``num_samples`` dataset (``uint32``) to ``ImageSeries`` to store the total number of frames
+  across all external files. This is needed when ``format='external'`` and timing is described using
+  ``starting_time`` and ``rate``, since ``data`` is empty and its first dimension cannot be used to determine
+  the number of frames. (#561, #543, #677, #678)
 - Improved documentation of ``ElectrodeGroup`` to clarify its purpose as a physical grouping of electrodes
   that are typically used together for analysis, such as spike sorting. (#659)
 - Specified that units for ``ElectrodesTable`` coordinate fields (``x``, ``y``, ``z``, ``rel_x``, ``rel_y``, ``rel_z``)
   should be in microns. (#658)
-- Expanded documentation for the ``Subject`` 'age' dataset, including details on ISO 8601 Duration format and 
+- Expanded documentation for the ``Subject`` 'age' dataset, including details on ISO 8601 Duration format and
   age range representation.
 
 2.9.0 (June 26, 2025)


### PR DESCRIPTION
This PR adds an optional `num_samples` dataset  to `ImageSeries`. When `format='external'`, `data` is an empty 3D array, so `data.shape[0]` is unavailable. The field is only needed when timing is described using `starting_time` and `rate` (when `timestamps` is provided, `len(timestamps)` already serves this purpose). It solves two problems:

- The total number of frames is unknown, making it impossible to compute the duration of the series via `num_samples / rate`. This is important to give summaries of time alignment without requiring us to open the video @bendichter (see #561)
- In the gapless multi-file case, the frame count of the last file cannot be derived from `starting_frame`, which only provides start indices with no upper bound for the final entry. (see #543)

This makes the `num_frames_per_external_file` proposal from #543 unnecessary, since the last file's frame count can be derived as `num_samples - starting_frame[-1]`.

Closes #561, closes #543, related to #677.



## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [x] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.


<!-- See https://nwb-schema.readthedocs.io/en/latest/software_process.html for more details. -->
