### PR TITLE
Fix RST errors in ophys docs and add Sphinx build CI check

### DIFF
--- a/.github/workflows/check_sphinx_build.yml
+++ b/.github/workflows/check_sphinx_build.yml
@@ -1,0 +1,37 @@
+name: Check Sphinx documentation build
+on:
+  pull_request:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+jobs:
+  check-sphinx-build:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout repo with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+          fetch-depth: 0  # tags are required for versioneer to determine the version
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Sphinx dependencies and package
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-doc.txt
+
+      - name: Generate RST sources from NWB spec
+        working-directory: docs/format
+        run: make apidoc
+
+      - name: Build HTML docs with warnings as errors
+        run: sphinx-build -n -W --keep-going -b html ./docs/format/source ./test_build

--- a/core/nwb.ophys.yaml
+++ b/core/nwb.ophys.yaml
@@ -61,7 +61,7 @@ groups:
         - width: fast scan direction (horizontal)
         - height: slow scan direction (vertical)
 
-      Coordinate system diagram:
+      Coordinate system diagram::
 
         height  ^
         (slow)  |
@@ -81,10 +81,10 @@ groups:
       for array access where the first index moves vertically through rows and the second moves horizontally
       through columns. In the schema, data[time, width, height] means that the first spatial
       index moves horizontally (width) through columns and the second spatial index moves
-      vertically (height) through rows. In summary, incrementing the first spatial index 
-      moves you horizontally across the image, while in matrix notation it would move you 
-      vertically across the rows of the image. 
-      
+      vertically (height) through rows. In summary, incrementing the first spatial index
+      moves you horizontally across the image, while in matrix notation it would move you
+      vertically across the rows of the image.
+
   links:
   - name: imaging_plane
     target_type: ImagingPlane
@@ -134,7 +134,7 @@ groups:
         - width: fast scan direction (horizontal)
         - height: slow scan direction (vertical)
 
-      Coordinate system diagram:
+      Coordinate system diagram::
 
         height  ^
         (slow)  |


### PR DESCRIPTION
## Summary
- Fix `Unexpected indentation` / `Line block ends without a blank line` docutils errors emitted by `make fulldoc` for the ASCII coordinate-system diagrams in `OnePhotonSeries.data` and `TwoPhotonSeries.data`. Adding `::` before the diagram makes it a literal block, so the `|` characters in the diagram render verbatim instead of being parsed as RST line block markup with inconsistent indentation.
- Add `.github/workflows/check_sphinx_build.yml`, which runs `make apidoc` and then `sphinx-build -n -W --keep-going -b html` on PRs and pushes to `dev`. With `-W`, any docutils warning fails CI. Verified locally: this workflow flags the original 2 ERROR / 2 WARNING set when the YAML fix is reverted, and passes after the fix is applied. Closes #682.

## Test plan
- [x] `make fulldoc` no longer reports docutils ERROR/WARNING for the ophys description files.
- [x] Reverting the YAML fix in isolation reproduces the original 4 issues under the new workflow's `sphinx-build -n -W --keep-going` invocation.
- [x] CI on this PR passes the new `Check Sphinx documentation build` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)