### PR TITLE
Harden CI against scheduled-workflow inactivity disable

### DIFF
--- a/.github/workflows/audit_disabled_workflows.yml
+++ b/.github/workflows/audit_disabled_workflows.yml
@@ -1,0 +1,67 @@
+name: Audit disabled workflows
+on:
+  push:
+    branches:
+      - dev
+  pull_request_target:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Find inactivity-disabled workflows and open an issue if any
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const workflows = await github.paginate(
+              github.rest.actions.listRepoWorkflows,
+              { owner, repo, per_page: 100 }
+            );
+            const disabled = workflows.filter(w => w.state === 'disabled_inactivity');
+            if (disabled.length === 0) {
+              core.info('No workflows in disabled_inactivity state.');
+              return;
+            }
+
+            const title = '[CI] Workflow(s) auto-disabled by GitHub for inactivity';
+            const existing = await github.paginate(
+              github.rest.issues.listForRepo,
+              { owner, repo, state: 'open', per_page: 100 }
+            );
+            if (existing.some(i => i.title === title)) {
+              core.info(`Open issue with title "${title}" already exists; skipping.`);
+              return;
+            }
+
+            const list = disabled
+              .map(w => `- **${w.name}** (\`${w.path}\`, id ${w.id})`)
+              .join('\n');
+            const body = [
+              'GitHub has auto-disabled the following workflow(s) for inactivity.',
+              'While in this state, the workflow does **not** run on any trigger,',
+              'including `pull_request` and `push`.',
+              '',
+              list,
+              '',
+              'To re-enable, run:',
+              '',
+              '```',
+              ...disabled.map(w => `gh workflow enable ${w.id} --repo ${owner}/${repo}`),
+              '```',
+              '',
+              'Or click "Enable workflow" in the Actions tab.',
+              '',
+              `Detected by \`${context.workflow}\` on ${new Date().toISOString()}.`,
+            ].join('\n');
+
+            await github.rest.issues.create({ owner, repo, title, body });
+            core.info(`Opened issue: ${title}`);

--- a/.github/workflows/check_sphinx_links.yml
+++ b/.github/workflows/check_sphinx_links.yml
@@ -1,8 +1,7 @@
 name: Check Sphinx external links and references
 on:
   pull_request:
-  schedule:
-    - cron: '0 5 * * *'  # once per day at midnight ET
+  workflow_call:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/check_sphinx_links_scheduled.yml
+++ b/.github/workflows/check_sphinx_links_scheduled.yml
@@ -1,0 +1,9 @@
+name: Check Sphinx external links and references (scheduled)
+on:
+  schedule:
+    - cron: '0 5 * * *'  # once per day at midnight ET
+  workflow_dispatch:
+
+jobs:
+  call-linkcheck:
+    uses: ./.github/workflows/check_sphinx_links.yml


### PR DESCRIPTION
Closes #684.

## Summary
- Split the linkcheck workflow so PR gating cannot be killed by inactivity. `check_sphinx_links.yml` now triggers on `pull_request:` + `workflow_call:` (no `schedule:`, so it cannot be auto-disabled). The daily cron lives in a new thin caller `check_sphinx_links_scheduled.yml` that reuses the PR workflow via `uses:` (no duplicated steps). If the scheduled file is ever auto-disabled, PR gating is unaffected.
- Add `audit_disabled_workflows.yml`. Runs on push to `dev`, on `pull_request_target` (chosen over `pull_request` so the audit also works on fork PRs, where `pull_request` would have a read-only token), and on `workflow_dispatch`. Calls the workflows API, filters for `state == 'disabled_inactivity'`, and opens a deduped issue. The audit has no `schedule:` trigger, so it cannot be auto-disabled itself.

`pull_request_target` is normally a security footgun when a workflow checks out and executes PR code; this audit does neither (only API calls), so the elevated token is safe here.

## Test plan
- [ ] CI passes on this PR (the new `Audit disabled workflows` job runs and is green; linkcheck PR job runs and is green).
- [ ] After merge, manually disable a low-impact workflow once and push a no-op commit to `dev`; confirm the audit creates an issue with the expected title and skips on a subsequent push (dedup works).
- [ ] Confirm the scheduled caller fires at 05:00 UTC the next day and reuses the linkcheck job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)