### PR TITLE
Make waveform units configurable

### DIFF
--- a/core/nwb.misc.yaml
+++ b/core/nwb.misc.yaml
@@ -268,8 +268,8 @@ groups:
       required: false
     - name: unit
       dtype: text
-      value: volts
-      doc: Unit of measurement. This value is fixed to 'volts'.
+      default_value: volts
+      doc: Unit of measurement. The default value is 'volts'.
       required: false
   - name: waveform_sd
     neurodata_type_inc: VectorData
@@ -295,8 +295,8 @@ groups:
       required: false
     - name: unit
       dtype: text
-      value: volts
-      doc: Unit of measurement. This value is fixed to 'volts'.
+      default_value: volts
+      doc: Unit of measurement. The default value is 'volts'.
       required: false
   - name: waveforms
     neurodata_type_inc: VectorData
@@ -332,8 +332,8 @@ groups:
         required: false
       - name: unit
         dtype: text
-        value: volts
-        doc: Unit of measurement. This value is fixed to 'volts'.
+        default_value: volts
+        doc: Unit of measurement. The default value is 'volts'.
         required: false
   - name: waveforms_index
     neurodata_type_inc: VectorIndex

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -8,6 +8,8 @@ Release Notes
 
 Bug fixes
 ^^^^^^^^^
+- ``Units.waveform_mean``, ``Units.waveform_sd``, and ``Units.waveforms`` now accept a unit other than the default
+  value, ``volts``.
 - Fixed copy-paste error in ``VoltageClampSeries.capacitance_slow`` unit attribute doc, which incorrectly
   referenced ``capacitance_fast``.
 - Fixed ``IntervalSeries.data`` resolution and unit attribute docs, which were verbatim copy-paste from


### PR DESCRIPTION
### Summary

`Units(waveform_unit="microvolts")` writes `volts` for all waveform datasets. This change writes the requested unit and keeps `volts` as the default. From NeurodataWithoutBorders/pynwb#2162.

### Design

Use `default_value` for `waveform_mean`, `waveform_sd`, and `waveforms`. This keeps the existing default and permits the API value.

The implementation changes [`core/nwb.misc.yaml`](https://github.com/stanbot8/nwb-schema/blob/6e6afca2d92fbcf5ac5dd75346845f76db868992/core/nwb.misc.yaml) and [`docs/format/source/format_release_notes.rst`](https://github.com/stanbot8/nwb-schema/blob/6e6afca2d92fbcf5ac5dd75346845f76db868992/docs/format/source/format_release_notes.rst). The design follows [Use default_value because this change is reasonable and non-breaking](https://github.com/NeurodataWithoutBorders/pynwb/issues/2162#issuecomment-5064489322).

### Tests

The HDMF validator accepts the complete core namespace. PyNWB writes and reads `microvolts` for all 3 waveform datasets. MatNWB reads all 3 HDF5 unit attributes.

The PyNWB relevant suite passes with `60` tests and `662` subtests. [The complete MatNWB R2025b suite](https://github.com/stanbot8/matnwb/actions/runs/30118924801) passes. An installed PyNWB wheel passes the custom unit case. The release note is included. The `hdmf-common-schema` pointer stays at `1.9.0` because `1.10.0` has an unrelated breaking `MeaningsTable` change.

Downstream validation includes [NeurodataWithoutBorders/matnwb](https://github.com/stanbot8/matnwb/actions/runs/30118924835) and [NeurodataWithoutBorders/pynwb](https://github.com/stanbot8/pynwb/blob/284e4e63630038a8493ec2d4f0b33ac86c97d65d/tests/integration/hdf5/test_misc.py).

<details>
<summary>Commands</summary>

```console
uvx --from git+https://github.com/hdmf-dev/hdmf.git validate_hdmf_spec core -m nwb.schema.json
PYNWB_NO_CACHE_DIR=1 python -m pytest tests/integration/hdf5/test_misc.py tests/unit/test_misc.py -q
```

</details>
