### PR TITLE
Add optional `time_before_peak_in_ms` to `waveform_mean` and `waveform_sd`

### DIFF
--- a/core/nwb.misc.yaml
+++ b/core/nwb.misc.yaml
@@ -266,6 +266,13 @@ groups:
       dtype: float32
       doc: Sampling rate, in hertz.
       required: false
+    - name: waveform_peak_time_ms
+      dtype: float32
+      doc: Time, in milliseconds, from the start of the waveform to the spike peak. The peak is the alignment point
+        used during spike sorting, typically the sample of maximum absolute amplitude. The same value applies to every
+        unit in the table. Together with 'sampling_rate' and the number of samples, this fully specifies where each
+        waveform sample falls relative to the spike event.
+      required: false
     - name: unit
       dtype: text
       default_value: volts
@@ -292,6 +299,13 @@ groups:
     - name: sampling_rate
       dtype: float32
       doc: Sampling rate, in hertz.
+      required: false
+    - name: waveform_peak_time_ms
+      dtype: float32
+      doc: Time, in milliseconds, from the start of the waveform to the spike peak. The peak is the alignment point
+        used during spike sorting, typically the sample of maximum absolute amplitude. The same value applies to every
+        unit in the table. Together with 'sampling_rate' and the number of samples, this fully specifies where each
+        waveform sample falls relative to the spike event.
       required: false
     - name: unit
       dtype: text

--- a/core/nwb.misc.yaml
+++ b/core/nwb.misc.yaml
@@ -266,6 +266,13 @@ groups:
       dtype: float32
       doc: Sampling rate, in hertz.
       required: false
+    - name: time_before_peak_in_ms
+      dtype: float32
+      doc: Time, in milliseconds, from the start of the waveform to the spike peak. The peak is the alignment point
+        used during spike sorting, typically the sample of maximum absolute amplitude. The same value applies to every
+        unit in the table. Together with 'sampling_rate' and the number of samples, this fully specifies where each
+        waveform sample falls relative to the spike event.
+      required: false
     - name: unit
       dtype: text
       default_value: volts
@@ -292,6 +299,13 @@ groups:
     - name: sampling_rate
       dtype: float32
       doc: Sampling rate, in hertz.
+      required: false
+    - name: time_before_peak_in_ms
+      dtype: float32
+      doc: Time, in milliseconds, from the start of the waveform to the spike peak. The peak is the alignment point
+        used during spike sorting, typically the sample of maximum absolute amplitude. The same value applies to every
+        unit in the table. Together with 'sampling_rate' and the number of samples, this fully specifies where each
+        waveform sample falls relative to the spike event.
       required: false
     - name: unit
       dtype: text

--- a/core/nwb.misc.yaml
+++ b/core/nwb.misc.yaml
@@ -344,6 +344,13 @@ groups:
         dtype: float32
         doc: Sampling rate, in hertz.
         required: false
+      - name: time_before_peak_in_ms
+        dtype: float32
+        doc: Time, in milliseconds, from the start of the waveform to the spike peak. The peak is the alignment point
+          used during spike sorting, typically the sample of maximum absolute amplitude. The same value applies to every
+          waveform in the table. Together with 'sampling_rate' and the number of samples, this fully specifies where
+          each waveform sample falls relative to the spike event.
+        required: false
       - name: unit
         dtype: text
         default_value: volts

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -8,10 +8,10 @@ Release Notes
 
 Minor changes
 ^^^^^^^^^^^^^
-- Added optional ``time_before_peak_in_ms`` attribute (``float32``) to ``Units.waveform_mean`` and
-  ``Units.waveform_sd`` to record the time from the start of the waveform to the spike peak, i.e., the alignment
-  point used during spike sorting. Previously, ``sampling_rate`` and the number of samples gave the duration of the
-  waveform window but not where the spike event falls within it. (#667, #709)
+- Added optional ``time_before_peak_in_ms`` attribute (``float32``) to ``Units.waveform_mean``,
+  ``Units.waveform_sd``, and ``Units.waveforms`` to record the time from the start of the waveform to the spike peak,
+  i.e., the alignment point used during spike sorting. Previously, ``sampling_rate`` and the number of samples gave
+  the duration of the waveform window but not where the spike event falls within it. (#667, #709)
 
 Bug fixes
 ^^^^^^^^^

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -6,6 +6,13 @@ Release Notes
 2.10.1 (Upcoming)
 -----------------
 
+Minor changes
+^^^^^^^^^^^^^
+- Added optional ``time_before_peak_in_ms`` attribute (``float32``) to ``Units.waveform_mean`` and
+  ``Units.waveform_sd`` to record the time from the start of the waveform to the spike peak, i.e., the alignment
+  point used during spike sorting. Previously, ``sampling_rate`` and the number of samples gave the duration of the
+  waveform window but not where the spike event falls within it. (#667, #709)
+
 Bug fixes
 ^^^^^^^^^
 - ``Units.waveform_mean``, ``Units.waveform_sd``, and ``Units.waveforms`` now accept a unit other than the default

--- a/docs/format/source/format_release_notes.rst
+++ b/docs/format/source/format_release_notes.rst
@@ -6,6 +6,13 @@ Release Notes
 2.10.1 (Upcoming)
 -----------------
 
+Minor changes
+^^^^^^^^^^^^^
+- Added optional ``waveform_peak_time_ms`` attribute (``float32``) to ``Units.waveform_mean`` and
+  ``Units.waveform_sd`` to record the time from the start of the waveform to the spike peak, i.e., the alignment
+  point used during spike sorting. Previously, ``sampling_rate`` and the number of samples gave the duration of the
+  waveform window but not where the spike event falls within it. (#667, #709)
+
 Bug fixes
 ^^^^^^^^^
 - ``Units.waveform_mean``, ``Units.waveform_sd``, and ``Units.waveforms`` now accept a unit other than the default


### PR DESCRIPTION
## Summary of changes

* Added the optional `time_before_peak_in_ms` attribute to `waveform_mean` and `waveform_sd`.
* Added the release notes entry for 2.10.1.

From a discussion with @alejoe91 in #667. `sampling_rate` and the shape give the duration of the waveform window but not where the peak sits inside it. This PR adds an optional `time_before_peak_in_ms` attribute with the time in milliseconds from the first sample to the peak, that is, the alignment point used during spike sorting. The value is the same for every unit and every spike, so it is an attribute and not a column.


This should close #667.

## Checklist

For all schema changes:
- [x] Add release notes for the PR to `docs/format/source/format_release_notes.rst`.
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
- [x] Make sure that `hdmf-common-schema` points to the latest release and not the latest commit on the `main` branch.

If this is the first schema change after a schema release (i.e., the version string in `core/nwb.namespace.yaml` does not
end in "-alpha"), then:
- [ ] Update the version string in `core/nwb.namespace.yaml` and `core/nwb.file.yaml` to the next major/minor/patch
  version with the suffix "-alpha". For example, if the current version is 2.4.0 and this is a minor change, then the
  new version string should be "2.5.0-alpha".
- [ ] Update the value of the `version` variable in `docs/format/source/conf.py` to the next version **without** the
  suffix "-alpha", e.g., "2.5.0".
- [ ] Update the value of the `release` variable in `docs/format/source/conf.py` to the next version **with** the suffix
  "-alpha", e.g., "2.5.0-alpha".
- [ ] Add a new section in the release notes `docs/format/source/format_release_notes.rst` for the new version
  with the date "Upcoming" in parentheses.

